### PR TITLE
[MARKENG-3366] Update "Sign In" text for Support Center

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "post-zen",
   "author": "Brandon Castillo, Marketing Engineering, Postman.",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "api_version": 2,
   "default_locale": "en-us",
   "settings": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-zendesk-support-theme",
-  "version": "1.3.5",
+  "version": "1.13.1",
   "author": "Brandon Castillo",
   "private": true,
   "scripts": {

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -269,7 +269,7 @@
           <a id="pm-signed-in" class="nav-link uber-nav"
             href="/hc/en-us/signin"
             onClick="ga('send', 'event', 'secondary-navbar', 'Click', 'sign-in');">
-            Sign in
+            Sign in to Support Center
           </a>
         </li>
       {{/unless}}


### PR DESCRIPTION
MARKENG-3367
- Request from Product Support
- Updates the sign-in text in the secondary navbar to indicate if users are signing into the Product or Zendesk platform.