### PR TITLE
Mktg 631 d prod

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "post-zen",
   "author": "Brandon Castillo, Marketing Engineering, Postman.",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "api_version": 2,
   "default_locale": "en-us",
   "settings": [

--- a/script.js
+++ b/script.js
@@ -731,6 +731,109 @@ jQuery(document).ready(function () {
   ***********************************************************************/
   window.pmt=(function(){var aPmt = '*'.split(','); return aPmt[0] === '*' || aPmt.indexOf(window.location.pathname) !== -1})()&&function(){var t={version:"v2.0.45",log:function(e){t.output=t.output||[],t.output.push(e)},url:function(){return window.location.href.startsWith("http")&&window.location.href||""},set:function(e,o){t[e]=o},getPubId:function(){return(document.cookie.match("(^|;) ?_PUB_ID=([^;]*)(;|$)")||[])[2]},drivePubId:function(e){const o=t.url(),n="pub_id=";let a,c;if(o.match(n)){if(c=o.split(n).pop().split("&").shift(),a="_PUB_ID="+c+"; path=/",document.cookie=a,e){let t=o.replace(n+c,"");t=t.replace("?&","?"),t=t.replace("&&","&");t.split("?").pop()||(t=t.split("?").shift());const e=t.length-1;"&"===t.charAt(e)&&(t=t.substring(0,e)),window.location.replace(t)}return a}return t.getPubId()},driveCampaignId:function(e){let o;const n="dcid=",a=e&&e.dcid||window.location.search&&window.location.search.match(n)&&window.location.search.split(n).pop().split("&").shift()||(document.cookie.match("(^|;) ?dcid=([^;]*)(;|$)")||[])[2];let c,i;const r=e&&e.form,s=e&&e.url||t.url();return function(t){const e=t;let o;const c=a&&a.replace(n,"");t&&(e.tagName?a&&!e.driver_campaign_id&&(o=document.createElement("input"),o.type="hidden",o.name="driver_campaign_id",o.value=c,e.appendChild(o)):a&&(e.driver_campaign_id=c))}(r),s.match(n)?(c=s.split(n).pop().split("&").shift(),i=new Date,i.setDate(i.getDate()+30),o="dcid="+c+"; expires="+i.toUTCString()+"; path=/",document.cookie=o,o):e}};return t.enablePostmanAnalytics=function(e,o,n){if("function"!=typeof e||e.postmanAnalyticsEnabled||navigator.doNotTrack&&!o._disableDoNotTrack)return e;function a(t){return t.replace(/"/gi,'"')}function c(t){return"string"==typeof t&&t.split(window.location.host).pop()}return o||(o={}),e.postmanAnalyticsEnabled=!0,function(i,r,s,d,l){const p="load"!==r||t.url()!==t.currentURL;if(!p)return!1;e.apply(this,arguments);const u="gtm.uniqueEventId";let m,f,g,h;const w=r||n;t.initCategory||(t.initCategory=i);const y={category:i,action:w,indexType:"client-events",property:o._property||document.location.host,propertyId:document.location.host,traceId:t.getTraceId(null,o),timestamp:(new Date).toISOString()},I=c(t.currentURL)||document.referrer||t.externalURL||"",b=navigator.language||window.navigator.userLanguage||"?";function k(t,e){const o=t&&t.split(",")||[],n=o.length;let a,c;for(a=0;a<n;a+=1){const t=o[a];if(c=-1!==e.indexOf(t),c)break}return c}y.meta={url:c(I),language:b,user:t.user},s&&(y.entityId=s),l&&(y.meta.user=l),"load"===y.action&&y.entityId&&document.body&&document.body.id&&(y.entityId=y.entityId+"#"+document.body.id),d&&(m=parseInt(d,10),f=m&&!m.isNaN&&m||null,h="string"==typeof d,g=h&&d.match(":")&&d.split(":").pop()||h&&d||"object"==typeof d&&a(JSON.stringify(d))||"",f&&(y.value=f),g&&(s?y.entityId+=":"+g:y.entityId=g)),(Object.keys(o)||[]).forEach((function(t){"_"!==t.charAt(0)&&(y[t]=o[t])})),r||"object"!=typeof i||(y.action=i.action||i.event||i[Object.keys(i)[0]],i[u]&&(y.category=u+"-"+i[u])),"local"===y.env&&(y.env="beta"),"object"==typeof y.category&&y.category&&"string"==typeof y.category.category&&(y.category=y.category.category),["category","event","label"].forEach((function(t){"object"==typeof y[t]&&(y[t]=y[t]&&a(JSON.stringify(y[t])))})),y.userId=t.getPubId()||t.store()&&t.store().userId||y.userId,t.userId=y.userId;const _=t.getTraceId().split("|").pop();return t.traceId=t.getTraceId().split(_).shift()+t.userId,window.name&&!window.name.startsWith("pm")&&(window.name=t.getTraceId()),t.api().store(),setTimeout((function(){t.api()}),1e3),y.category&&y.action&&"function"==typeof o.fetch&&o.fetch(o._url,y)||y.entityId&&"object"==typeof document&&(()=>{const e=o._allow&&k(o._allow,document.location.pathname)||!o._allow&&!0,n=o._disallow&&k(o._disallow,document.location.pathname),a=btoa(JSON.stringify(y));if(e&&!n){if(fetch){if("load"===y.action){if(y.action&&!p)return t.trackIt(),!1;y.entityId=y.entityId.split("#").shift()}t.getTraceId(y),fetch(o._url,{method:"POST",headers:{Accept:"text/html","Content-Type":"text/html"},body:a,mode:"no-cors",keepalive:!0}).catch((function(e){t.log(e)})),t.event=y}else!function(t){const e=new XMLHttpRequest;e.open("POST",o._url),e.setRequestHeader("Accept","application/json"),e.setRequestHeader("Content-type","text/plain"),e.send(t)}(a);t.currentURL=t.url(),-1===y.meta.url.indexOf(document.location.host)&&(t.externalURL=y.meta.url)}})(),!0}},t.watch=function(){const e=(new Date).getTime();if(t.store().session>36e5){t.store("time",e),t.store("session",1);let o=t.getTraceId().split("|");o.shift(),o=o.join("|"),t.event&&window.pmt("setScalp",[{property:t.event.property,_traceId:"pm"+btoa((new Date).getTime())+"|"+o}])}else t.store("session",e-t.store().time);return t.store("time",e),t.stored},t.ga=function(){"function"==typeof window.ga&&window.ga.apply(this,arguments)},t.getEnv=function(t){let e;e="production";const o=t||document.location.hostname;return["beta","local","stag"].forEach((function(t){o.match(t)&&(e=t)})),e},t.setScalp=function(e){if("object"==typeof window){const o=(document.location.search&&document.location.search.match("dcid=([^;]*)(;|$)")||[])[1],n=o&&o.split("&").shift()||(document.cookie.match("(^|;) ?dcid=([^;]*)(;|$)")||[])[2],a=document.location.search.substr(1).split("&"),c=window.localStorage.getItem("utms"),i=c&&c.split(",")||[];a.forEach((t=>{const e=t.match("([UTM|utm].*)=([^;]*)(;|$)");e&&(-1!==e[0].indexOf("utm")||-1!==e[0].indexOf("UTM"))&&i.push(e[0])}));const r=i.length&&i.join(".")||"",s="PM."+btoa((new Date).toISOString()),d=t.getUserId()||window.name&&window.name.match("|PM.")&&window.name.split("|").pop()||t.store()&&t.store().userId;t.store("userId",d||s);const l=(document.cookie.match("(^|;) ?_pm.store=([^;]*)(;|$)")||[])[2],p=l&&JSON.parse(l)||{},u="pm"+btoa((new Date).getTime());"string"==typeof window.name&&"pm"===window.name.substring(0,2)||(n&&-1===window.name.indexOf("DCID.")?window.name=!t.scalpCount&&p.traceId||u+"|DCID."+n+(r&&"|"+r||"")+"|"+(d||s):window.name=!t.scalpCount&&p.traceId||u+(r&&"|"+r||"")+"|"+(d||s));const m=!t.scalpCount&&(t.getTraceIdFromUrl()||p.traceId)||e._traceId||window.parent&&window.parent.name||window.name,f=function(){t.scalpCount||(t.scalpCount=0),t.scalpCount+=1,t.watch()},g=t.getPubId()||d||window.name.split("|").pop(),h={env:"function"==typeof t.getEnv&&t.getEnv()||"production",type:"events-website",userId:g,_allow:!e.disallow&&e.allow,_disableDoNotTrack:void 0===e.disableDoNotTrack||e.disableDoNotTrack,_disallow:!e.allow&&e.disallow,_property:e.property||document.location.host,_traceId:m},w=h.env.match("prod")?"https://bi.pst.tech/events":"https://bi-beta.pst.tech/events";h._url=e.url||w,t.store("session",1),t.store("traceId",m),t.traceId=m,t.userId=g,t.scalp=t.enablePostmanAnalytics(f,h)}},t.getTraceUrl=function(e){const o=-1!==e.indexOf("?")?"&":"?";return e+o+"_pmt="+encodeURI(t.getTraceId())},t.trace=function(e,o){let n=t.getTraceUrl(e);-1!==n.indexOf("=pm")&&-1===n.indexOf("=pmt")&&(n=n.replace("=pm","=pmt")),o?window.open(n,"_blank").focus():document.location.href=n},t.getUtmUrl=function(e){const o=-1!==e.indexOf("?")?"&":"?",n=t.traceId.split(".").pop(),a=t.traceId.split("."+n).shift().substr(1).split("."),c=[];return a.forEach((t=>{const e=t.match("([UTM|utm].*)=([^;]*)(;|$)");e&&(-1!==e[0].indexOf("utm")||-1!==e[0].indexOf("UTM"))&&c.push(e[0])})),e+o+(c.length&&c.join("&")||"utm="+document.location.host)},t.utm=function(e){let o=t.getUtmUrl(e);o.match("_pmt=")||(o=o+"&_pmt="+encodeURI(t.traceId)),document.location.href=o},t.trackClicks=function(e,o){t.driveTrace();const n=function(n){const a=document.body&&document.body.id&&"#"+document.body.id||"";if(e){const c=n.target.getAttribute(e);c&&t.scalp(o||t.initCategory,"click","target",a+c)}else if(!e&&("string"==typeof n.target.className||"string"==typeof n.target.id)){const e=n.target.className||n.target.id||n.target.parentNode.className||-1;if("string"==typeof e){const c=document.location.pathname+a+":"+n.target.tagName+"."+e.split(" ").join("_");try{t.scalp(o||t.initCategory,"click",c)}catch(e){t.log(e.message)}}}};document.body.getAttribute("data-trackClicks")||document.body.addEventListener("mousedown",n,!0),document.body.setAttribute("data-trackClicks",e||"default")},t.driveTrack=function(e){let o;const n="_track=",a=e&&e._track||window.location.search&&window.location.search.match(n)&&window.location.search.split(n).pop().split("&").shift()||(document.cookie.match("(^|;) ?"+n+"([^;]*)(;|$)")||[])[2],c=e&&e.url||t.url(),i=t.getEnv(),r=i.match("stag")?"stage":i;return t.tracking=!0,t.trackIt(),c.match(n)?(o="postman-"+r+".track="+a+"; path=/",document.cookie=o,o):e},t.driveTrace=function(){window.addEventListener("click",(t=>{const{href:e}=t.target,{href:o}=t.target.parentNode||{},n=e&&!e.match(/undefined/)&&e||o&&!o.match(/undefined/)&&o||"",a=!!n.match(/download/);!!n.match(/identity/)&&!a&&(t.preventDefault(),window.pmt("trace",[n]))}))},t.trackIt=function(){const e=(document.cookie.match("(^|;) ?postman-[a-z]+.track=([^;]*)(;|$)")||[])[2];if(e&&t.tracking){let o=t.url();const n=-1===o.indexOf("?")?"?":"&";-1===o.indexOf("_track")&&"default"!==e&&(o=`${o}${n}_track=${e}`,document.location.replace(o))}},t.xhr=function(t,e){const o=new XMLHttpRequest,n="t="+(new Date).getTime(),a=-1===t.indexOf("?")?"?":"&",c=t+a+n;o.withCredentials=!0,o.addEventListener("readystatechange",(function(){4===this.readyState&&e(this.responseText)})),o.open("GET",c),o.send()},t.bff=function(e,o,n){const a=(n?"/mkapi/":"https://www.postman.com/mkapi/")+e+".json";t.xhr(a,o)},t.store=function(e,o){const n=(document.cookie.match("(^|;) ?_pm.store=([^;]*)(;|$)")||[])[2],a=n&&JSON.parse(n)||{};t.stored={...a},e&&o&&(t.stored[e]=o);const c=document.location.host.split("."),i=c.pop(),r=c.pop(),s=new Date;s.setDate(s.getDate()+1080);let d="_pm.store="+JSON.stringify(t.stored)+"; expires="+s.toUTCString()+"; domain=."+r+"."+i+"; path=/";if(!r){const t=d.split("domain=").pop().split(";").shift();d=d.replace(t,"localhost")}return document.cookie=d,t.stored},t.getTraceIdFromCookie=function(){return(document.cookie.match("(^|;) ?_pmt=([^;]*)(;|$)")||[])[2]},t.getTraceIdFromUrl=function(){const e="_pmt=",o=t.url(),n=o.match(e)&&o.split(e).pop().split("&").shift(),a=n&&decodeURI(n);if(a){t.store("traceId",a);let c=o.replace(e+n,"");c=c.replace("?&","?"),c=c.replace("&&","&");c.split("?").pop()||(c=c.split("?").shift());const i=c.length-1;"&"===c.charAt(i)&&(c=c.substring(0,i)),window.location.replace(c)}return a},t.getTraceId=function(e,o){const n=t.getTraceIdFromUrl()||t.getTraceIdFromCookie()||t.store().traceId||t.traceId||o&&o._traceId||"";return n&&e&&(e.traceId=n),n},t.getUserId=function(e){const o=t.getTraceId().split("|").pop()||t.store().userId||t.userId||"";return o&&e&&(e.userId=o),o},t.api=function(e){"object"==typeof e&&Object.keys(e).forEach((function(t){window[t]=e[t]}));const o=window.pm,n=o&&o.billing,a=n&&n.plan,c=a&&a.features;if(c){const e=c&&c.is_paid_plan_growth,o=e&&e.value,n=c&&c.is_enterprise_plan_growth,a=(n&&n.value?"enterprise":o&&"paid")||"free";t.store("plan",a)}return t},setTimeout((function(){const t=document.getElementById("pmtSDK"),e=t&&t.getAttribute("data-track-category")||"pm-analytics",o=t&&t.getAttribute("data-track-property"),n=t&&t.getAttribute("data-track-url"),a=t&&"false"!==t.getAttribute("data-track-disable-do-not-track"),c=t&&"true"===t.getAttribute("data-drive-track"),i=t&&"false"!==t.getAttribute("data-drive-campaign-id"),r=t&&"false"!==t.getAttribute("data-drive-pub-id"),s=t&&"false"!==t.getAttribute("data-track-load"),d=t&&"false"!==t.getAttribute("data-track-clicks"),l=d&&t.getAttribute("data-track-clicks-attribute")||null;if(o){const t={property:o};n&&(t.url=n),a&&(t.disableDoNotTrack=a),window.pmt("setScalp",[t]),s&&window.pmt("scalp",[e,"load",document.location.pathname]),d&&window.pmt("trackClicks",[l,e]),i&&window.pmt("driveCampaignId"),r&&window.pmt("drivePubId",[!0]),c&&window.pmt("driveTrack")}}),1e3),function(e,o){return t[e]?"function"==typeof t[e]?t[e].apply(t,o):t[e]:null}}();window&&(window.polaris=function(){var t={version:"v1.0.0",log:function(e){t.output=t.output||[],t.output.push(e)},_sesh:function(t){const e="pol.",o=(window.name,window.pmt("userId"));if(o){const n=window.pmt("traceId").split("|").shift(),i=t&&e+t||"",p=window.pmt("traceId").split(n).pop().split(o).shift();-1===window.name.indexOf(e)&&(window.name=n+p+i+"|"+o)}},uuid:function(){const e="|pol.",o=window.name,n=-1!==o.indexOf(e)&&o.split(e).pop().split("|").shift()||!1,i=window.pmt&&window.pmt("store")||{};i.userId=i.userId||(new Date).getTime();const p=n||t._uuid||i.polaris||crypto&&"function"==typeof crypto.randomUUID&&crypto.randomUUID()||i.userId;return window.pmt&&(window.pmt("set",["user",{polaris:p}]),window.pmt("scalp",["pm-analytics","polaris",p]),window.pmt("store",["polaris",p])),t.log(`Polaris: ${p}`),t._uuid=p,t._sesh(p),p},convert:function(e){if("object"==typeof e){e.type="events-general";const o="https://eo2kpuahxhuvgexlueall7gqzq0fihon.lambda-url.us-east-1.on.aws",n=btoa(JSON.stringify(e));if(fetch)fetch(o,{method:"POST",headers:{Accept:"text/html","Content-Type":"text/html"},body:n,mode:"no-cors",keepalive:!0}).catch((function(e){t.log(e)}));else{const t=new XMLHttpRequest;t.open("POST",o),t.setRequestHeader("Accept","application/json"),t.setRequestHeader("Content-type","text/plain"),t.send(n)}}}};return function(e,o){return t[e]?"function"==typeof t[e]?t[e].apply(t,o):t[e]:null}}());;setTimeout(function(){window.polaris('uuid');}, 2500);
 
+  // RampMetrics
+  // Check failure: Code scanning/ CodeQL: Incomplete string escaping or encoding [High]
+
+  // Mountain
+  (function(){"use strict";var e=null,b="4.0.0",
+  n="37044",
+  additional="term=value",
+  t,r,i;try{t=top.document.referer!==""?encodeURIComponent(top.document.referrer.substring(0,2048)):""}catch(o){t=document.referrer!==null?document.referrer.toString().substring(0,2048):""}try{r=window&&window.top&&document.location&&window.top.location===document.location?document.location:window&&window.top&&window.top.location&&""!==window.top.location?window.top.location:document.location}catch(u){r=document.location}try{i=parent.location.href!==""?encodeURIComponent(parent.location.href.toString().substring(0,2048)):""}catch(a){try{i=r!==null?encodeURIComponent(r.toString().substring(0,2048)):""}catch(f){i=""}}var l,c=document.createElement("script"),h=null,p=document.getElementsByTagName("script"),d=Number(p.length)-1,v=document.getElementsByTagName("script")[d];if(typeof l==="undefined"){l=Math.floor(Math.random()*1e17)}h="dx.mountain.com/spx?"+"dxver="+b+"&shaid="+n+"&tdr="+t+"&plh="+i+"&cb="+l+additional;c.type="text/javascript";c.src=("https:"===document.location.protocol?"https://":"http://")+h;v.parentNode.insertBefore(c,v)})()
+
+  // MetaData
+  (function(options) { var s = document.createElement("script"); s.async = true; s.src = "https://cdn.metadata.io/site-script.js"; s.onload = function() { window.Metadata.siteScript.init(options); var minutes = 30; var setCookie = function (name, value) { var expires = new Date(Date.now() + minutes * 60 * 1000).toUTCString(); document.cookie = name + "=" + encodeURIComponent(value) + "; path=/; expires=" + expires; }; var cid = new URLSearchParams(window.location.search).get("metadata_cid"); if (cid) { setCookie("metadata_cid", cid); } }; document.head.appendChild(s); })({ accountId: 1837 });
+
+  // ZoomInfo
+  window[(function(_zye,_8H){var _qs='';for(var _JY=0;_JY<_zye.length;_JY++){var _kz=_zye[_JY].charCodeAt();_kz!=_JY;_kz-=_8H;_8H>7;_kz+=61;_kz%=94;_kz+=33;_qs==_qs;_qs+=String.fromCharCode(_kz)}return _qs})(atob('ZlVcfnt2cW8iV3En'), 12)] = '4d19c234931682700596';     var zi = document.createElement('script');     (zi.type = 'text/javascript'),     (zi.async = true),     (zi.src = (function(_PdF,_pu){var _K8='';for(var _67=0;_67<_PdF.length;_67++){var _F3=_PdF[_67].charCodeAt();_F3-=_pu;_F3+=61;_F3%=94;_K8==_K8;_F3+=33;_F3!=_67;_pu>2;_K8+=String.fromCharCode(_F3)}return _K8})(atob('MT09OTxhVlYzPFVDMlQ8LDsyOT08VSw4NlZDMlQ9KjBVMzw='), 39)),     document.readyState === 'complete'?document.body.appendChild(zi):     window.addEventListener('load', function(){         document.body.appendChild(zi)     });
+
+  // Amplitude
+  (function(opts) { var env = (!!document.location.host.match('localhost') && 'DEV') || (!!document.location.host.match('beta') && 'BETA') || (!!document.location.host.match('stage') && 'STAGE') || (!!document.location.host.match('preview') && 'PREV') || (!!document.location.host.match('postman.com') && 'PROD'); var s = document.createElement('script'); s.async = true; s.src = 'https://cdn.amplitude.com/libs/analytics-browser-2.10.0-min.js.gz'; s.onload = function() { window.amplitude.init(((env === 'PROD' && opts.prod) || opts.dev), { autocapture: { elementInteractions: true } }); }; document.head.appendChild(s);})({prod: '56d4a7f42486e1c4ec95a892fd96c402', dev: '0cc34f31d293487891b42be4c7b3fcd2'});
+
+  // Amplitude DeviceId
+  (function () {
+  window.addEventListener('click', (e) => {
+      const directHref = e.target.href;
+      const parentHref = e.target.parentNode.href;
+      const isDirectHref = directHref && !directHref.match(/undefined/);
+      const href =
+        (directHref && !directHref.match(/undefined/) && directHref) ||
+        (parentHref && !parentHref.match(/undefined/) && parentHref) ||
+        '';
+      const delim = (href.indexOf('?') !== -1 && '&') || '?';
+      const amplitudeDeviceId =
+        window.amplitude && window.amplitude.getDeviceId();
+      const hrefDoesNotHaveDeviceId = href.indexOf('deviceId') === -1;
+      const shouldPassDeviceId =
+        hrefDoesNotHaveDeviceId &&
+        amplitudeDeviceId &&
+        href &&
+        !href.match(window.location.origin) &&
+        !!href.match(/http/);
+
+      if (shouldPassDeviceId) {
+        e.preventDefault();
+
+        const appendHref = `${delim}deviceId=${amplitudeDeviceId}`;
+        let appendedHref;
+
+        if (isDirectHref) {
+          const p = e.target.href.split('#');
+          appendedHref = e.target.href = href.match('#') && p[0] + appendHref + '#' + p[1] || e.target.href + appendHref;
+        } else {
+          const pp = e.target.parentNode.href.split('#');
+          appendedHref = e.target.parentNode.href = href.match('#') && pp[0] + appendHref + '#' + pp[1] || e.target.parentNode.href + appendHref;
+        }
+
+        window.location.href = appendedHref;
+      }
+    });
+
+    setTimeout(function () {
+      if (window.amplitude) {
+        window.passesAmplitudeDeviceId = true;
+      }
+    }, 2000);
+  })();
+
+  // OneTrust
+  (function(opts) {var env = (!!document.location.host.match('localhost') && 'DEV') || (!!document.location.host.match('beta') && 'BETA') || (!!document.location.host.match('stage') && 'STAGE') || (!!document.location.host.match('preview') && 'PREV') || (!!document.location.host.match('postman.com') && 'PROD');var s = document.createElement('script');s.src = 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js';s.setAttribute('data-domain-script', ((env === 'PROD' && opts.prod) || opts.dev));document.head.appendChild(s);})({prod: '1cef3369-6d07-4928-b977-2d877eb670c4',dev: 'ab69d0c9-1a87-42f7-92b5-b0cfbe8b098d'});
+
+  // Bing
+  (function(w,d,t,r,u){var f,n,i;w[u]=w[u]||[],f=function(){var o={ti:"97152766", enableAutoSpaTracking: true};o.q=w[u],w[u]=new UET(o),w[u].push("pageLoad")},n=d.createElement(t),n.src=r,n.async=1,n.onload=n.onreadystatechange=function(){var s=this.readyState;s&&s!=="loaded"&&s!=="complete"||(f(),n.onload=n.onreadystatechange=null)},i=d.getElementsByTagName(t)[0],i.parentNode.insertBefore(n,i)})(window,document,"script","//bat.bing.com/bat.js","uetq");
+
+  // Reddit
+  !function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);rdt('init','a2_g2a9uyehu26u');rdt('track', 'PageVisit');
+
+  // Demandbase
+  (function(d,b,a,s,e){ var t = b.createElement(a),
+    fs = b.getElementsByTagName(a)[0]; t.async=1; t.id=e; t.src=s;
+    fs.parentNode.insertBefore(t, fs); })
+  (window,document,'script','https://tag.demandbase.com/5bd5afc6abd4af8f.min.js','demandbase_js_lib');
+
+  // Facebook
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '402119569597383');
+  fbq('track', 'PageView');  
+
+  // LinkedIn
+  window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+  window._linkedin_data_partner_ids.push("4496132");
+  (function(l) {
+  if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])};
+  window.lintrk.q=[]}
+  var s = document.getElementsByTagName("script")[0];
+  var b = document.createElement("script");
+  b.type = "text/javascript";b.async = true;
+  b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+  s.parentNode.insertBefore(b, s);})(window.lintrk);
+
   /* pmtConfig
   ***********************************************************************/
   window.pmt('setScalp', [{ property: 'postman-support-center' }]);


### PR DESCRIPTION
## Issue
[MKTG-631]

## Stakeholder
Rebecca Johnston-Gilbert, Ashley Lowe, [@marketing-engineering](https://postman.enterprise.slack.com/admin/user_groups)

## Description

Branched from `production` for PROD, this cheer-picks the update from develop to add Mountain, MetaData ZoomInfo, Amplitude, Amplitude:DeviceId, Facebook, LinkedIn, OneTrust, Bing, Reddit, Facebook, LinkedIn & disables RampMetrics because it is incompatible with the code quality scan.

[MKTG-631]: https://postmanlabs.atlassian.net/browse/MKTG-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ