### PR TITLE
Add/update the GigaML widget to Support Center

### DIFF
--- a/templates/document_head.hbs
+++ b/templates/document_head.hbs
@@ -87,3 +87,23 @@ s.parentNode.insertBefore(b, s);})(window.lintrk);
 
   gtag('config', 'AW-821881030');
 </script>
+
+<!-- GigaML Chat Widget -->
+<script>
+  // Configure your chat widget
+  window.CHAT_WIDGET_CONFIG = {
+    agent_template_id: "agent_template_31b1be89-1135-4dbb-ba80-45367eee74e5"
+    company_name: "Postman",
+    tagline: "Ready when you are.",
+    primary_color: "#FF6C37",
+    primary_text_color: "#fff",
+    secondary_color: "rgb(245 245 245)",
+    secondary_text_color: "#000000"
+    position: "bottom-right",
+    icon_url: "https://voyager.postman.com/logo/postman-logo-icon-orange.svg",
+    secondary_color: "rgb(245 245 245)",
+    org_id: "YOUR_ORG_ID" // Optional
+  };
+</script>
+
+<script src="https://widget.gigaml.com/inject-gigaml.js" defer></script>


### PR DESCRIPTION
This adds the GigaML script to the Support Center and disables the default Zendesk widget. It will need to be tested in the BETA environment (not accessible to public)  

https://support.postman.com/hc/en-us