### PR TITLE
MKTG-9235 Add GPC opt-out notice banner

### DIFF
--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -314,3 +314,22 @@
     {{search submit=false instant=settings.instant_search placeholder='Search Postman support center' class='search search-full nav-search__form ml-5 mr-4'}}
   </div>
 </nav>
+
+<!-- GPC Opt-Out Notice (MKTG-9235) -->
+<script>
+(self.airgap={readyQueue:[],ready(cb){this.readyQueue.push(cb);},...self.airgap}).ready(function(airgap){
+  var hasGPC=airgap.getPrivacySignals().has('GPC');
+  var purposes=[...airgap.getRegimePurposes()];
+  var types=airgap.getPurposeTypes();
+  var affected=hasGPC&&purposes.some(function(p){return types[p].optOutSignals.includes('GPC');});
+  if(affected){
+    var h=document.querySelector('.nav-secondary');
+    var hHeight=h?h.offsetHeight:0;
+    var n=document.createElement('div');
+    n.style.cssText='background:#1c1c1c;color:#fff;text-align:center;padding:12px;font-size:16px;position:fixed;top:'+hHeight+'px;left:0;width:100%;z-index:99999;box-sizing:border-box;';
+    n.setAttribute('role','status');
+    n.innerHTML='Global Privacy Control Honored <button onclick="this.parentElement.remove();try{sessionStorage.setItem(\'gpc-banner-dismissed\',\'1\')}catch(e){}" style="position:absolute;right:12px;top:50%;transform:translateY(-50%);background:none;border:none;color:#fff;font-size:24px;cursor:pointer;" aria-label="Dismiss GPC notice">&times;</button>';
+    try{if(!sessionStorage.getItem('gpc-banner-dismissed')){document.body.appendChild(n);}}catch(e){document.body.appendChild(n);}
+  }
+});
+</script>

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -326,7 +326,7 @@
     var h=document.querySelector('.nav-secondary');
     var hHeight=h?h.offsetHeight:0;
     var n=document.createElement('div');
-    n.style.cssText='background:#1c1c1c;color:#fff;text-align:center;padding:12px;font-size:16px;position:fixed;top:'+hHeight+'px;left:0;width:100%;z-index:99999;box-sizing:border-box;';
+    n.style.cssText='background:#1c1c1c;color:#fff;text-align:center;padding:12px;font-size:16px;font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;position:fixed;top:'+hHeight+'px;left:0;width:100%;z-index:99999;box-sizing:border-box;';
     n.setAttribute('role','status');
     n.innerHTML='Global Privacy Control Honored <button onclick="this.parentElement.remove();try{sessionStorage.setItem(\'gpc-banner-dismissed\',\'1\')}catch(e){}" style="position:absolute;right:12px;top:50%;transform:translateY(-50%);background:none;border:none;color:#fff;font-size:24px;cursor:pointer;" aria-label="Dismiss GPC notice">&times;</button>';
     try{if(!sessionStorage.getItem('gpc-banner-dismissed')){document.body.appendChild(n);}}catch(e){document.body.appendChild(n);}


### PR DESCRIPTION
## Summary
- Adds a "Global Privacy Control Honored" banner when a visitor's browser has GPC enabled and their region has purposes affected by GPC opt-out signals
- Uses Transcend airgap readyQueue to detect GPC signal and applicable regime
- Banner is fixed-position below the secondary nav, dismissible, and persisted per session via sessionStorage
- Script injected in header.hbs after the secondary nav element

## Test plan
- [ ] Enable GPC in browser (e.g. [Global Privacy Control Inspector](https://chromewebstore.google.com/detail/global-privacy-control-inspector/ahnfjgckgocajaadjganddcagainkicp) extension)
- [ ] Verify banner appears below nav with correct styling and Inter font
- [ ] Dismiss banner and verify it doesn't reappear during the session
- [ ] Open a new session and verify it reappears
- [ ] Verify banner does not appear when GPC is disabled