### PR TITLE
feat: render the global navbar and footer from the shared web component

### DIFF
--- a/templates/document_head.hbs
+++ b/templates/document_head.hbs
@@ -28,6 +28,29 @@
 <link href="https://voyager.postman.com/font/fonts.css" rel="stylesheet" />
 <!-- Bootstrap v5 -->
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+{{!--
+  Shared global navbar/footer bundle. ONE script registers both elements.
+
+  This is the HYDRATE build, not the plain client build: the navbar in
+  header.hbs is prerendered Declarative Shadow DOM, and this bundle adopts that
+  existing markup in place instead of throwing it away and re-rendering (which
+  would flash and shift). It also registers <postman-footer>, which
+  client-mounts.
+
+  A module script defers, so it never blocks the parser. crossorigin is
+  required rather than decorative: module scripts are always CORS-fetched, and
+  SRI needs it too.
+
+  VERSION AND INTEGRITY MUST CHANGE TOGETHER, and must match the version of the
+  navbar fragment inlined in header.hbs. A stale hash makes the browser refuse
+  the script, leaving the navbar rendered but inert.
+--}}
+<script
+  type="module"
+  src="https://global-navbar-footer.postman-account2009.workers.dev/1.0.6/global-navbar-footer.hydrate.js"
+  integrity="sha384-yW5DuHn5b2o8ltGedX9uFBVMLoyFIL9jNVqL6tyP7eGH7MsG5Xjqgzm2eaCrmUSS"
+  crossorigin="anonymous"></script>
+
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2"
     crossorigin="anonymous"></script>

--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -1,363 +1,55 @@
+{{!--
+  GLOBAL FOOTER — shared <postman-footer> from
+  postman-eng/marketing-global-navbar-footer, replacing ~360 lines of
+  hand-inlined markup that duplicated the marketing site's footer.
+
+  CLIENT-MOUNTED, unlike the navbar above. The footer is below the fold and not
+  LCP-critical, so there is no prerendered fragment; the element reserves its own
+  height (--pm-footer-min-height) and fills in on mount, so no layout shift.
+  It is registered by the same bundle the navbar's hydration uses — see
+  templates/document_head.hbs — so no extra script is needed here.
+
+  No `host` attribute: it falls back to location.origin, and support.postman.com
+  is not www-family, so internal links resolve to absolute www.postman.com URLs.
+
+  emit-jsonld is left ON (the default). Unlike the docs site, the support center
+  has no competing SiteNavigationElement data of its own, so letting the
+  component emit it is a net gain rather than a duplicate.
+--}}
 <div>
-    <hr>
-    <footer>
-        <section id="Footer" class="section">
-            <div class="container">
-                <div class="row ">
-                    <div class="col-sm-8 offset-sm-2 col-md-12 offset-md-0">
-                        <div class="row">
-                            <!-- First Column -->
-                            <div class="col-12 offset-0  col-md-2 offset-md-0 col-lg-2 order-lg-first order-last">
-                                <img width="174" height="auto" class="footer-img d-block mx-auto mx-lg-0"
-                                    src="https://voyager.postman.com/logo/postman-logo-orange-stacked.svg"
-                                    alt="Postman logo" />
-                            </div>
-                            <!-- Second column  -->
-                            <div class="col-6 col-md-4 col-lg-2 mb-2 mb-md-0">
-                                <nav aria-labelledby="product">
-                                    <h2 class="footer-col-title" id="product">
-                                        Product
-                                    </h2>
-                                    <ul class="footer-column">
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/product/what-is-postman/"
-                                                id="what-is-postman"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'what-is-postman');">What
-                                                is Postman?</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/postman-enterprise/" id="enterprise"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'enterprise');">Enterprise</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/product/spec-hub/" id="flows"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'spec-hub');">Spec
-                                                Hub</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/product/flows/" id="flows"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'flows');">Flows</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/product/postbot/" id="postbot"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'postbot');">Postbot</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/downloads/#postman-vs-code-extension"
-                                                id="vs-code-extension"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'vs-code-extension');">VS
-                                                Code Extension</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/downloads#postman-cli" id="postman-cli"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'postman-cli');">Postman
-                                                CLI</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/product/integrations/" id="integrations"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'integrations');">Integrations</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/product/tools/" id="tools"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'tools');">Tools</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/product/governance/" id="api-governance"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'api-governance');">API
-                                                Governance</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/product/workspaces/" id="workspaces"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'workspaces');">Workspaces</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/pricing/" id="pricing"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'pricing');">Plans
-                                                and pricing</a></li>
-                                    </ul>
-                                </nav>
-                            </div>
-                            <!-- Third Column API Network -->
-                            <div class="col-6 col-md-4 col-lg-2 ">
-                                <nav aria-labelledby="api-network" class="mb-2">
-                                    <h2 class="footer-col-title" id="api-network">
-                                        API Network
-                                    </h2>
-                                    <ul class="footer-column">
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/category/app-security/" id="api-security"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'api-security');">App
-                                                Security</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/category/artificial-intelligence/"
-                                                id="artificial-intelligence"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'artificial-intelligence');">Artificial
-                                                Intelligence</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/category/communication/"
-                                                id="communication"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'communication');">
-                                                Communication</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/category/data-analytics/"
-                                                id="data-analytics"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'data-analytics');">Data
-                                                Analytics</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/category/database-apis/" id="database"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'database');">Database</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/category/developer-productivity/"
-                                                id="developer-productivity"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'developer-productivity');">Developer
-                                                Productivity</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/category/devops/" id="dev-ops"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'dev-ops');">DevOps</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/category/e-commerce-apis/" id="ecommerce"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'ecommerce');">Ecommerce</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/category/e-signature-apis/"
-                                                id="esignature"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'esignature');">eSignature</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/category/financial-services/"
-                                                id="financial-services"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'financial-services');">Financial
-                                                Services</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/category/payments/" id="payments"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'payments');">Payments</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/category/travel-apis/" id="travel-apis"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'travel-apis');">Travel</a>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                            <!-- Fourth Column  Resources-->
-                            <div class="col-6 col-md-4 col-lg-2  no-select">
-                                <nav aria-labelledby="resources" class="mb-5">
-                                    <h2 class="footer-col-title" id="resources">
-                                        Resources
-                                    </h2>
-                                    <ul class="footer-column">
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://learning.postman.com/docs/introduction/overview/"
-                                                id="postman-docs"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'postman-docs');">Postman
-                                                Docs</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://academy.postman.com/" id="postman-academy"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'postman-academy');">Academy</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://community.postman.com/" id="community"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'community');">Community</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/templates/" id="postman-templates"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'postman-templates');">Templates</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/events/intergalactic/"
-                                                id="postman-intergalactic"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'postman-intergalactic');">Intergalactic</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.youtube.com/c/Postman/" id="postman-videos"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'postman-videos');">Videos</a>
-                                        </li>
-                                         <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/explore/mcp-servers/" id="mcp-servers"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'postman-mcp-servers');">MCP Servers<span class="dropdown__badge">NEW</span></a>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                            <!-- Fifth Column Legal and Security -->
-                            <div class="col-6 col-md-4 col-lg-2  no-select">
-                                <nav aria-labelledby="legal-and-security" class="mb-5">
-                                    <h2 class="footer-col-title" id="legal-and-security">
-                                        Legal and Security
-                                    </h2>
-                                    <ul class="footer-column">
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/legal/" id="legal-terms-hub"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'legal-terms-hub');">Legal Terms Hub
-                                            </a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/legal/terms/" id="terms-of-service"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'terms-of-service');">Terms
-                                                of Service</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/legal/postman-product-terms/" id="product-terms"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'product-terms');">Product Terms</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/trust/" id="trust-and-safety"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'trust-and-safety');">Trust
-                                                and Safety</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/legal/postman-website-terms-of-use/" id="website-terms-of-use"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'website-terms-of-use');">Website Terms of Use</a></li>
-                                    </ul>
-                                </nav>
-                            </div>
-                            <!-- Sixth Column Company  -->
-                            <div class="col-6 col-md-4 col-lg-2 no-select">
-                                <nav aria-labelledby="company" class="mb-5">
-                                    <h2 class="footer-col-title" id="company">
-                                        Company
-                                    </h2>
-                                    <ul class="footer-column">
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/company/about-postman/" id="about"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'about');">About</a>
-                                        </li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/company/careers/" id="careets-and-culture"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'careets-and-culture');">Careers
-                                                and culture</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/company/contact-us/" id="contact-us"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'contact-us');">Contact
-                                                us</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/partner-program/" id="partner-program"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'partner-program');">Partner
-                                                program</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/case-studies/" id="customer-stories"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'customer-stories');">Customer
-                                                stories</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/student-program/" id="student-programs"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'student-programs');">Student
-                                                programs</a></li>
-                                        <li class="footer-column-row"><a class="footer-link"
-                                                href="https://www.postman.com/company/press-media/" id="press-and-media"
-                                                onClick="ga('send', 'event', 'global-footer', 'Click', 'press-and-media');">Press
-                                                and media</a></li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-12 mt-3 mt-lg-0">
-                        <ul class="list-unstyled d-flex justify-content-center justify-content-lg-end mb-0">
-                            <li class="footer-li-item">
-                                <a class="footer-social-svg" href="https://x.com/getpostman" id="x"
-                                    onClick="ga('send', 'event', 'global-footer', 'Click', 'x');">
+  <hr>
+  <postman-footer>
+    {{!--
+      Support-owned consent control, projected into the component's `privacy`
+      slot. Carried over as-is, including the Transcend guard that logs rather
+      than failing silently when an ad blocker leaves the manager unloaded.
 
-                                    <svg xmlns='http://www.w3.org/2000/svg' width="14" height="14"
-                                        viewBox='0 0 1200 1227' fill='none'>
-                                        <path
-                                            d='M714.163 519.284L1160.89 0H1055.03L667.137 450.887L357.328 0H0L468.492 681.821L0 1226.37H105.866L515.491 750.218L842.672 1226.37H1200L714.137 519.284H714.163ZM569.165 687.828L521.697 619.934L144.011 79.6944H306.615L611.412 515.685L658.88 583.579L1055.08 1150.3H892.476L569.165 687.854V687.828Z'
-                                            fill="#010000" />
-                                    </svg>
-
-                                </a>
-
-                            </li>
-                            <li class="footer-li-item ">
-                                <a class="footer-social-svg" href="https://www.linkedin.com/company/postman-platform"
-                                    id="linkedin" onClick="ga('send', 'event', 'global-footer', 'Click', 'linkedin');">
-                                    <svg width="16" height="16" viewBox="0 0 25 25" xmlns="http://www.w3.org/2000/svg">
-                                        <path
-                                            d="M5.134 7.363H.537v14.044h4.597zM5.437 3.019C5.407 1.642 4.44.593 2.866.593 1.293.593.265 1.642.265 3.019c0 1.348.998 2.427 2.541 2.427h.03c1.603 0 2.601-1.079 2.601-2.427zM21.714 13.354c0-4.313-2.268-6.32-5.293-6.32-2.44 0-3.534 1.362-4.144 2.319v-1.99H7.68c.06 1.318 0 14.044 0 14.044h4.598v-7.843c0-.42.03-.839.151-1.139.333-.839 1.09-1.707 2.36-1.707 1.664 0 2.329 1.288 2.329 3.175v7.514h4.597v-8.053z"
-                                            fill="#0e76a8" fillRule="evenodd"></path>
-                                    </svg>
-                                </a>
-                            </li>
-                            <li class="footer-li-item">
-                                <a class="footer-social-svg " href="https://github.com/postmanlabs" id="github"
-                                    onClick="ga('send', 'event', 'global-footer', 'Click', 'github');">
-                                    <svg height="16" class="octicon octicon-mark-github" viewBox="0 0 16 16"
-                                        version="1.1" width="16" aria-hidden="true">
-                                        <path fill="#24292f" fillRule="evenodd"
-                                            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z">
-                                        </path>
-                                    </svg>
-                                </a>
-                            </li>
-                            <li class="footer-li-item">
-                                <a class="footer-social-svg" href="https://www.youtube.com/c/Postman" id="youtube"
-                                    onClick="ga('send', 'event', 'global-footer', 'Click', 'youtube');">
-                                    <svg height='16' width='16' enable-background='new 0 0 30 21.14'
-                                        viewBox='0 0 30 21.14' xmlns='http://www.w3.org/2000/svg'>
-                                        <path
-                                            d='m29.37 3.3c-.35-1.3-1.36-2.32-2.65-2.67-2.34-.63-11.72-.63-11.72-.63s-9.38 0-11.72.63c-1.29.35-2.31 1.37-2.65 2.67-.63 2.36-.63 7.27-.63 7.27s0 4.91.63 7.27c.35 1.3 1.36 2.32 2.65 2.67 2.34.63 11.72.63 11.72.63s9.38 0 11.72-.63c1.29-.35 2.31-1.37 2.65-2.67.63-2.36.63-7.27.63-7.27s0-4.91-.63-7.27zm-17.44 11.73v-8.92l7.84 4.46z'
-                                            fill='#c4302b'></path>
-                                    </svg>
-                                </a>
-                            </li>
-                            <li class="footer-li-item">
-                                <a class="footer-social-svg" href="https://www.instagram.com/getpostman" id="instagram"
-                                    onClick="ga('send', 'event', 'global-footer', 'Click', 'instagram');">
-                                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 132.004 132"><defs><linearGradient id="b"><stop offset="0" stop-color="#3771c8"/><stop stop-color="#3771c8" offset=".128"/><stop offset="1" stop-color="#60f" stop-opacity="0"/></linearGradient><linearGradient id="a"><stop offset="0" stop-color="#fd5"/><stop offset=".1" stop-color="#fd5"/><stop offset=".5" stop-color="#ff543e"/><stop offset="1" stop-color="#c837ab"/></linearGradient><radialGradient id="c" cx="158.429" cy="578.088" r="65" xlink:href="#a" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 -1.98198 1.8439 0 -1031.402 454.004)" fx="158.429" fy="578.088"/><radialGradient id="d" cx="147.694" cy="473.455" r="65" xlink:href="#b" gradientUnits="userSpaceOnUse" gradientTransform="matrix(.17394 .86872 -3.5818 .71718 1648.348 -458.493)" fx="147.694" fy="473.455"/></defs><path fill="url(#c)" d="M65.03 0C37.888 0 29.95.028 28.407.156c-5.57.463-9.036 1.34-12.812 3.22-2.91 1.445-5.205 3.12-7.47 5.468C4 13.126 1.5 18.394.595 24.656c-.44 3.04-.568 3.66-.594 19.188-.01 5.176 0 11.988 0 21.125 0 27.12.03 35.05.16 36.59.45 5.42 1.3 8.83 3.1 12.56 3.44 7.14 10.01 12.5 17.75 14.5 2.68.69 5.64 1.07 9.44 1.25 1.61.07 18.02.12 34.44.12 16.42 0 32.84-.02 34.41-.1 4.4-.207 6.955-.55 9.78-1.28 7.79-2.01 14.24-7.29 17.75-14.53 1.765-3.64 2.66-7.18 3.065-12.317.088-1.12.125-18.977.125-36.81 0-17.836-.04-35.66-.128-36.78-.41-5.22-1.305-8.73-3.127-12.44-1.495-3.037-3.155-5.305-5.565-7.624C116.9 4 111.64 1.5 105.372.596 102.335.157 101.73.027 86.19 0H65.03z" transform="translate(1.004 1)"/><path fill="url(#d)" d="M65.03 0C37.888 0 29.95.028 28.407.156c-5.57.463-9.036 1.34-12.812 3.22-2.91 1.445-5.205 3.12-7.47 5.468C4 13.126 1.5 18.394.595 24.656c-.44 3.04-.568 3.66-.594 19.188-.01 5.176 0 11.988 0 21.125 0 27.12.03 35.05.16 36.59.45 5.42 1.3 8.83 3.1 12.56 3.44 7.14 10.01 12.5 17.75 14.5 2.68.69 5.64 1.07 9.44 1.25 1.61.07 18.02.12 34.44.12 16.42 0 32.84-.02 34.41-.1 4.4-.207 6.955-.55 9.78-1.28 7.79-2.01 14.24-7.29 17.75-14.53 1.765-3.64 2.66-7.18 3.065-12.317.088-1.12.125-18.977.125-36.81 0-17.836-.04-35.66-.128-36.78-.41-5.22-1.305-8.73-3.127-12.44-1.495-3.037-3.155-5.305-5.565-7.624C116.9 4 111.64 1.5 105.372.596 102.335.157 101.73.027 86.19 0H65.03z" transform="translate(1.004 1)"/><path fill="#fff" d="M66.004 18c-13.036 0-14.672.057-19.792.29-5.11.234-8.598 1.043-11.65 2.23-3.157 1.226-5.835 2.866-8.503 5.535-2.67 2.668-4.31 5.346-5.54 8.502-1.19 3.053-2 6.542-2.23 11.65C18.06 51.327 18 52.964 18 66s.058 14.667.29 19.787c.235 5.11 1.044 8.598 2.23 11.65 1.227 3.157 2.867 5.835 5.536 8.503 2.667 2.67 5.345 4.314 8.5 5.54 3.054 1.187 6.543 1.996 11.652 2.23 5.12.233 6.755.29 19.79.29 13.037 0 14.668-.057 19.788-.29 5.11-.234 8.602-1.043 11.656-2.23 3.156-1.226 5.83-2.87 8.497-5.54 2.67-2.668 4.31-5.346 5.54-8.502 1.18-3.053 1.99-6.542 2.23-11.65.23-5.12.29-6.752.29-19.788 0-13.036-.06-14.672-.29-19.792-.24-5.11-1.05-8.598-2.23-11.65-1.23-3.157-2.87-5.835-5.54-8.503-2.67-2.67-5.34-4.31-8.5-5.535-3.06-1.187-6.55-1.996-11.66-2.23-5.12-.233-6.75-.29-19.79-.29zm-4.306 8.65c1.278-.002 2.704 0 4.306 0 12.816 0 14.335.046 19.396.276 4.68.214 7.22.996 8.912 1.653 2.24.87 3.837 1.91 5.516 3.59 1.68 1.68 2.72 3.28 3.592 5.52.657 1.69 1.44 4.23 1.653 8.91.23 5.06.28 6.58.28 19.39s-.05 14.33-.28 19.39c-.214 4.68-.996 7.22-1.653 8.91-.87 2.24-1.912 3.835-3.592 5.514-1.68 1.68-3.275 2.72-5.516 3.59-1.69.66-4.232 1.44-8.912 1.654-5.06.23-6.58.28-19.396.28-12.817 0-14.336-.05-19.396-.28-4.68-.216-7.22-.998-8.913-1.655-2.24-.87-3.84-1.91-5.52-3.59-1.68-1.68-2.72-3.276-3.592-5.517-.657-1.69-1.44-4.23-1.653-8.91-.23-5.06-.276-6.58-.276-19.398s.046-14.33.276-19.39c.214-4.68.996-7.22 1.653-8.912.87-2.24 1.912-3.84 3.592-5.52 1.68-1.68 3.28-2.72 5.52-3.592 1.692-.66 4.233-1.44 8.913-1.655 4.428-.2 6.144-.26 15.09-.27zm29.928 7.97c-3.18 0-5.76 2.577-5.76 5.758 0 3.18 2.58 5.76 5.76 5.76 3.18 0 5.76-2.58 5.76-5.76 0-3.18-2.58-5.76-5.76-5.76zm-25.622 6.73c-13.613 0-24.65 11.037-24.65 24.65 0 13.613 11.037 24.645 24.65 24.645C79.617 90.645 90.65 79.613 90.65 66S79.616 41.35 66.003 41.35zm0 8.65c8.836 0 16 7.163 16 16 0 8.836-7.164 16-16 16-8.837 0-16-7.164-16-16 0-8.837 7.163-16 16-16z"/></svg>
-                                </a>
-                            </li>
-                            <li class="footer-li-item">
-                                <a class="footer-social-svg mr-2" href="https://discord.gg/58aNNsRBGR" id="discord" rel="noopener" target="_blank"
-                                    onClick="ga('send', 'event', 'global-footer', 'Click', 'discord');">
-                                    <svg xmlns="http://www.w3.org/2000/svg" shape-rendering="geometricPrecision" text-rendering="geometricPrecision" image-rendering="optimizeQuality" fill-rule="evenodd" clip-rule="evenodd" viewBox="0 0 512 388.049"><path fill="#5865F2" fill-rule="nonzero" d="M433.713 32.491A424.231 424.231 0 00328.061.005c-4.953 8.873-9.488 18.156-13.492 27.509a393.937 393.937 0 00-58.629-4.408c-19.594 0-39.284 1.489-58.637 4.37-3.952-9.33-8.543-18.581-13.525-27.476-36.435 6.212-72.045 17.196-105.676 32.555-66.867 98.92-84.988 195.368-75.928 290.446a425.967 425.967 0 00129.563 65.03c10.447-14.103 19.806-29.116 27.752-44.74a273.827 273.827 0 01-43.716-20.862c3.665-2.658 7.249-5.396 10.712-8.055 40.496 19.019 84.745 28.94 129.514 28.94 44.77 0 89.019-9.921 129.517-28.943 3.504 2.86 7.088 5.598 10.712 8.055a275.576 275.576 0 01-43.796 20.918 311.49 311.49 0 0027.752 44.705 424.235 424.235 0 00129.65-65.019l-.011.011c10.632-110.26-18.162-205.822-76.11-290.55zM170.948 264.529c-25.249 0-46.11-22.914-46.11-51.104 0-28.189 20.135-51.304 46.029-51.304 25.895 0 46.592 23.115 46.15 51.304-.443 28.19-20.336 51.104-46.069 51.104zm170.102 0c-25.29 0-46.069-22.914-46.069-51.104 0-28.189 20.135-51.304 46.069-51.304s46.472 23.115 46.029 51.304c-.443 28.19-20.296 51.104-46.029 51.104z"/></svg>
-                                </a>
-                            </li>
-                        </ul>
-                        </nav>
-                    </div>
-                </div>
-                <hr class="footer-hr mt-4" />
-                <div class="">
-                    <div class="row mt-4 px-3">
-                        <div class="col-12 col-lg-2 text-lg-start text-center mb-2 mb-lg-0 p-0">
-                            <a href="https://www.postman.com/downloads/" class="dynamic-link__external"
-                                onClick="ga('send', 'event', 'global-footer', 'Click', 'download-postman');">Download
-                                Postman</a>
-                        </div>
-                         <div class="col-12 col-lg-2 text-lg-start text-center mb-2 mb-lg-0 p-0">
-                            <a href="https://privacy.postman.com/policies/" class="dynamic-link__external"
-                                onClick="ga('send', 'event', 'global-footer', 'Click', 'privacy-policy');">Privacy Policy</a>
-                        </div>
-                        <div class="col-12 col-lg-4 text-lg-start text-center mb-2 mb-lg-0 pl-lg-1">
-                             <button
-                                onclick="handleDoNotSellClick()"
-                                aria-label="Manage your privacy settings"
-                                class="privacy-consent-btn"
-                                style="background: none; border: none; padding: 0; cursor: pointer; color: #0d6efd; font-weight: 400;"
-                                >
-                                Do Not Sell or Share My Personal Information
-                            </button>
-                        </div>
-
-                        <div class="col-12 col-lg-4 text-lg-end text-center p-0">
-                            <span class="copyright">
-                                <p class="mb-0">© <span id="current-year">2024</span> Postman, Inc.</p>
-                            </span>
-                        </div>
-                    </div>
-        </section>
-        <script>
-            document.addEventListener('DOMContentLoaded', function () {
-                const yearElement = document.getElementById('current-year');
-                if (yearElement) {
-                    yearElement.textContent = new Date().getFullYear();
-                }
-            });
-        </script>
-        <script>
-            // Privacy consent manager function
-            function handleDoNotSellClick() {
-                if (typeof window !== 'undefined' && window.transcend) {
-                    window.transcend.showConsentManager({ viewState: 'DoNotSellExplainer' });
-                } else {
-                    console.warn('Transcend consent manager not available');
-                }
-            }
-        </script>
-    </footer>
+      The Privacy Policy link and the copyright line are deliberately NOT carried
+      over: the shared footer renders both, to the same
+      privacy.postman.com/policies/ target, and computes the year itself — which
+      also retires the DOMContentLoaded script that used to patch #current-year
+      (it was hardcoded to 2024 in the markup).
+    --}}
+    <div slot="privacy" class="pm-support-privacy">
+      <button
+        type="button"
+        onclick="handleDoNotSellClick()"
+        aria-label="Do Not Sell or Share My Personal Information"
+        class="privacy-consent-btn"
+        style="background: none; border: none; padding: 0; cursor: pointer; color: #0d6efd; font-weight: 400;"
+      >
+        Do Not Sell or Share My Personal Information
+      </button>
+    </div>
+  </postman-footer>
+  <script>
+    // Privacy consent manager, unchanged from the previous footer.
+    function handleDoNotSellClick() {
+      if (typeof window !== 'undefined' && window.transcend) {
+        window.transcend.showConsentManager({ viewState: 'DoNotSellExplainer' });
+      } else {
+        console.warn('Transcend consent manager not available');
+      }
+    }
+  </script>
 </div>

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -1,413 +1,1624 @@
 <div class="alertbox"></div>
-<nav class="navbar-v6 navbar navbar-expand-xl navbar-light nav-primary" aria-label="Main" style="z-index: 10000">
-  <a class="navbar-brand" href="https://www.postman.com/" aria-label="Home">
-    <div class="navbar-logo-container">
-      <img src="https://voyager.postman.com/logo/postman-logo-icon-orange.svg" alt="Postman" width="32" height="32" />
-    </div>
-  </a>
-  <button
-    id="postman-primary-nav"
-    class="mobile-icon-button navbar-toggler"
-    type="button"
-    data-test="navbar-mobile-icon"
-    data-bs-toggle="collapse"
-    data-bs-target="#navbarSupportedContent"
-    aria-controls="navbarSupportedContent"
-    aria-expanded="false"
-    aria-label="Toggle navigation menu">
-    <span class="navbar-toggler-icon mobile-icon_span">
-      <div id="icon-wrap-one" class="icon-bar mobile-icon" aria-expanded="false">
-        <span></span>
-        <span></span>
-        <span></span>
-        <span></span>
-      </div>
-    </span>
-  </button>
 
-  <div class="collapse navbar-collapse" id="navbarSupportedContent">
-    <ul class="navbar-nav me-auto">
+{{!--
+  GLOBAL NAVBAR — GENERATED, do not hand-edit.
 
-      <!-- Product -->
-      <li class="nav-item dropdown">
-        <a
-          class="nav-link dropdown-toggle"
-          href="#"
-          id="Nav-Product"
-          data-bs-toggle="dropdown"
-          data-bs-display="static"
+  Prerendered <postman-navbar> from postman-eng/marketing-global-navbar-footer,
+  inlined verbatim. Refresh on a version bump with:
+
+    curl -fsS https://global-navbar-footer.postman-account2009.workers.dev/v1/navbar.foreign.en.html
+
+  ...then re-insert the two slot blocks below the markup and update the version
+  and integrity hash in templates/document_head.hbs. No build step, no npm, no
+  Node — the artifact is static HTML.
+
+  It is inlined rather than client-mounted so the navbar is SERVER-RENDERED:
+  Zendesk emits this template, so the browser's parser sees the
+  <template shadowrootmode> and attaches the shadow root. That keeps the markup
+  and its links in the initial HTML. (Assigning it with innerHTML on the client
+  would attach no shadow root at all.)
+
+  `foreign` variant: support.postman.com is not www-family, so internal links
+  resolve to absolute https://www.postman.com/... URLs, matching what the
+  hand-written nav did.
+
+  Verified safe for Handlebars: the fragment contains zero {{ or }} sequences,
+  so nothing in it is parsed as a Handlebars expression.
+
+  The support-specific secondary nav below — Sign in / My requests / Discord and
+  the {{search}} helper — is unchanged and stays a sibling.
+--}}
+<!--lit-part BQm9WKKK8Pc=--><!--lit-node 0--><postman-navbar {{#if signed_in}}signed-in {{/if}}locale="en"><template shadowroot="open" shadowrootmode="open"><style>
+    /* Design tokens match www.postman.com's GlobalNavbar (Inter, white bar,
+       54px tall, grey→#212121 triggers, white rounded mega-menu panel). */
+    :host {
+      display: block;
+      font-family: var(--pm-font, 'Inter', system-ui, -apple-system, sans-serif);
+    }
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 55;
+      display: flex;
+      align-items: center;
+      box-sizing: border-box;
+      height: 54px;
+      background: var(--pm-nav-bg, #fff);
+      border-bottom: 1px solid var(--pm-nav-border, #e6e6e6);
+      padding: 0.8rem 1.6rem;
+    }
+    /* Default account controls (slot fallback). Plain shadow CSS, no utility
+       classes: Fern's custom-header compiler silently no-ops Tailwind arbitrary
+       values and screen variants, so anything relying on them would compute to
+       defaults there. */
+    .acct-group {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+    .acct-group.acct-mobile {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.6rem;
+      width: 100%;
+    }
+    .acct {
+      font: inherit;
+      font-size: 0.85rem;
+      font-weight: 600;
+      line-height: 1;
+      padding: 0.5rem 0.8rem;
+      border-radius: 4px;
+      text-decoration: none;
+      white-space: nowrap;
+      border: 1px solid transparent;
+    }
+    .acct-secondary {
+      color: var(--pm-nav-fg, #212121);
+      border-color: var(--pm-nav-border, #e6e6e6);
+    }
+    .acct-secondary:hover {
+      border-color: var(--pm-nav-fg, #212121);
+    }
+    .acct-primary {
+      background: var(--pm-nav-accent, #ff6c37);
+      color: #fff;
+    }
+    .acct-primary:hover {
+      background: var(--pm-nav-accent-hover, #e35c2c);
+    }
+    .acct:focus-visible {
+      outline: 2px solid var(--pm-nav-accent, #ff6c37);
+      outline-offset: 2px;
+    }
+
+    /* Default logo (slot fallback). A host that projects its own into
+       slot="logo" replaces this entirely, so these rules stop applying — style
+       the projected element from the host page instead. */
+    .logo {
+      display: inline-flex;
+      align-items: center;
+      flex: none;
+      margin-right: 1.6rem;
+      border: 0;
+      text-decoration: none;
+    }
+    .logo img {
+      display: block;
+      width: 32px;
+      height: 32px;
+    }
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    .menubar {
+      display: flex;
+      align-items: center;
+      gap: 0;
+    }
+    .trigger,
+    .top-link {
+      font: inherit;
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 21px;
+      letter-spacing: normal;
+      color: var(--pm-nav-link, #6b6b6b);
+      background: none;
+      border: 0;
+      padding: 0 15px;
+      cursor: pointer;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      white-space: nowrap;
+    }
+    .trigger[aria-expanded='true'],
+    .trigger:hover,
+    .top-link:hover {
+      color: var(--pm-nav-link-hover, #212121);
+    }
+    .chevron {
+      width: 12px;
+      height: 12px;
+      transition: transform 0.2s ease-in-out;
+      transform: scale(0.85);
+    }
+    .trigger[aria-expanded='true'] .chevron {
+      transform: rotate(180deg) scale(0.85);
+    }
+    :focus-visible {
+      outline: 2px solid var(--pm-focus-ring, #ff6c37);
+      outline-offset: 2px;
+    }
+    .item {
+      position: relative;
+      /* Source wraps each top-level item in mx-[8px]; combined with the
+         trigger's 15px padding this gives the bar its item spacing. */
+      margin: 0 8px;
+    }
+    /* A closed panel is [hidden]. The UA display:none must win over the
+       author display:flex on .panel.has-brands (same specificity), or the
+       Product dropdown stays visible on load. */
+    .panel[hidden] {
+      display: none !important;
+    }
+    .panel {
+      position: absolute;
+      top: 100%;
+      left: -14px;
+      z-index: 2147483647;
+      margin-top: 0.8rem;
+      width: max-content;
+      box-sizing: border-box;
+      background: var(--pm-panel-bg, #fff);
+      border: 1px solid var(--pm-panel-border, #e6e6e6);
+      border-radius: 10px;
+      box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.2);
+      padding: 20px;
+    }
+    /* Source has NO gap between columns: spacing comes from fixed column
+       widths + each item's 10px padding. */
+    .columns {
+      display: flex;
+      gap: 0;
+      align-items: flex-start;
+    }
+    .col {
+      box-sizing: border-box;
+    }
+    .col.w210 {
+      width: 210px;
+    }
+    .col.w180 {
+      width: 180px;
+    }
+    /* Product's Platform/Explore column: narrower, rendered last, with a
+       20px gap (margin) + divider separating it from the icon columns. */
+    .col.left-nav {
+      width: 190px;
+      margin-left: 20px;
+      border-left: 1px solid #e6e6e6;
+      padding-left: 20px;
+    }
+    /* Solutions: all items in one 2-column grid, equal-height rows. */
+    .solutions-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-auto-rows: 1fr;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      width: 410px;
+      max-width: 100%;
+    }
+    .col-title,
+    .section-header {
+      margin: 0 0 10px 10px;
+      font-family: var(--pm-mono, 'IBM Plex Mono', ui-monospace, 'SFMono-Regular', monospace);
+      font-size: 12px;
+      font-weight: 400;
+      text-transform: uppercase;
+      color: var(--pm-nav-section, #e05320);
+    }
+    .section-header {
+      margin-top: 30px;
+    }
+    .menu-item {
+      display: flex;
+      gap: 8px;
+      align-items: flex-start;
+      padding: 10px;
+      border-radius: 5px;
+      text-decoration: none;
+      color: #212121;
+      transition: background-color 0.15s ease-in-out;
+    }
+    .menu-item:hover {
+      background: var(--pm-nav-hover-bg, #efefef);
+    }
+    .menu-item .title {
+      display: block;
+      font-size: 14px;
+      font-weight: 600;
+      color: #212121;
+    }
+    .menu-item .desc {
+      display: block;
+      font-size: 12px;
+      color: #5c5c5c;
+    }
+    .menu-item img {
+      width: 22px;
+      height: 22px;
+      margin-top: 1px;
+      flex-shrink: 0;
+    }
+    .menu-item.app-cta .title {
+      color: #0265d2;
+      font-weight: 400;
+    }
+    .menu-item.app-cta:hover {
+      background: none;
+    }
+    /* Featured "AI cards" row: full-width grey cards below the columns. */
+    .featured {
+      margin-top: 10px;
+      padding-top: 20px;
+      border-top: 1px solid #e6e6e6;
+    }
+    .card-row {
+      display: flex;
+      flex-wrap: nowrap;
+      gap: 8px;
+    }
+    .card-row > li {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+    .featured .menu-item {
+      height: 100%;
+      box-sizing: border-box;
+      background: #f9f9f9;
+    }
+    /* Cards carry an inline gradient; hover keeps it and adds the ring +
+       a subtle darken (mirrors the source's ring + brightness hover). */
+    .featured .feat-card {
+      box-shadow: 0 0 0 0.5px transparent;
+      transition:
+        box-shadow 0.15s ease-in-out,
+        filter 0.15s ease-in-out;
+    }
+    .featured .feat-card:hover {
+      background: inherit;
+      box-shadow: 0 0 0 1px var(--ring, #efefef);
+      filter: brightness(0.98);
+    }
+    /* "More from Postman": grey shell + white inner panel + grey brands
+       sidebar, mirroring the live Product mega-menu (NavDropdownMenu). */
+    .panel.has-brands {
+      display: flex;
+      flex-direction: row;
+      padding: 0;
+      background: var(--pm-brands-bg, #f9f8f7);
+    }
+    .panel-inner {
+      display: flex;
+      flex-direction: column;
+      box-sizing: border-box;
+      /* Fixed width (like the source's xl:w-[895px]) so the featured card row
+         can't expand the panel past the column grid: content width 861px =
+         3×210 icon columns + the 190px Platform column with its 20px gap +
+         20px pad + 1px divider. This makes the 4 flex cards ≈210px each, so
+         they line up under the columns above. */
+      width: 901px;
+      background: var(--pm-panel-bg, #fff);
+      border-radius: 10px;
+      padding: 20px;
+      box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.2);
+    }
+    .brands-panel {
+      display: flex;
+      flex-direction: column;
+      width: 220px;
+      flex-shrink: 0;
+      box-sizing: border-box;
+      padding: 20px;
+    }
+    .brand-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      padding: 10px;
+      border-radius: 5px;
+      text-decoration: none;
+      color: #212121;
+      transition: opacity 0.15s ease-in-out;
+    }
+    .brand-item:hover {
+      opacity: 0.8;
+    }
+    .brand-item img {
+      width: 20px;
+      height: 20px;
+      margin-top: 1px;
+      flex-shrink: 0;
+    }
+    .brand-item .title {
+      display: inline-flex;
+      align-items: center;
+      font-size: 14px;
+      font-weight: 600;
+      color: #212121;
+    }
+    .brand-item .desc {
+      display: block;
+      font-size: 12px;
+      color: #5c5c5c;
+    }
+    .brand-arrow {
+      display: inline-flex;
+      align-items: center;
+      vertical-align: middle;
+      margin-left: 5px;
+      position: relative;
+      top: -1px;
+    }
+    .brand-arrow .bar {
+      height: 1px;
+      width: 7px;
+      background-color: currentColor;
+      transition: width 0.2s ease-in-out;
+    }
+    .brand-arrow .chev {
+      display: block;
+      margin-left: -4px;
+    }
+    .brand-item:hover .brand-arrow .bar,
+    .brand-item:focus .brand-arrow .bar {
+      width: 12px;
+    }
+    .hamburger {
+      display: none;
+      font: inherit;
+      background: none;
+      border: 1px solid var(--pm-nav-border, #e6e6e6);
+      border-radius: 6px;
+      padding: 0.4rem 0.6rem;
+      cursor: pointer;
+      color: #212121;
+    }
+    .actions {
+      margin-left: auto;
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+    }
+
+    /* Host controls for the MOBILE drawer. The "account" slot renders in the
+       top bar, which has no room on a phone — and a named slot can only be
+       projected once, so the drawer needs its own. Hidden above the mobile
+       breakpoint so hosts can supply both without double-rendering.
+       (Never use a backtick in this file's CSS comments — the whole block is a
+       css tagged template literal, so a stray one terminates it.) */
+    .mobile-account {
+      display: none;
+    }
+
+    @media (max-width: 1200px) {
+      /* The open menu needs a row of its own BELOW the bar. Without wrapping,
+         .menubar{width:100%} can't break to a new line — it just takes the
+         leftover space beside the logo and hamburger (~300px on a phone) — and
+         the bar's fixed 54px height clips it. So: allow wrapping, and let the
+         bar grow once the menu is open while keeping 54px as the closed height. */
+      nav {
+        flex-wrap: wrap;
+        height: auto;
+        min-height: 54px;
+        align-content: flex-start;
+      }
+      /* Host-supplied slot content (auth buttons, switchers) must not force the
+         bar wider than the viewport — it's authored by the consumer and can be
+         any width. Let it shrink and wrap rather than overflow the page. */
+      .actions {
+        min-width: 0;
+        flex-wrap: wrap;
+      }
+      .hamburger {
+        display: inline-block;
+        order: 2;
+      }
+      .mobile-account {
+        display: block;
+        padding: 0.5rem 0;
+        border-top: 1px solid var(--pm-nav-border, #e6e6e6);
+        margin-top: 0.25rem;
+      }
+      .menubar {
+        display: none;
+        flex-direction: column;
+        align-items: stretch;
+        width: 100%;
+        order: 3;
+      }
+      .menubar[data-mobile-open='true'] {
+        display: flex;
+      }
+      .panel {
+        position: static;
+        width: auto;
+        max-width: none;
+        margin-top: 0;
+        box-shadow: none;
+        border: 0;
+        border-radius: 0;
+        padding: 0.5rem 0 0.5rem 1rem;
+      }
+      .columns {
+        flex-direction: column;
+        gap: 1rem;
+      }
+      /* Stack the brands sidebar below the columns on small screens. */
+      .panel.has-brands {
+        flex-direction: column;
+        background: none;
+        padding: 0.5rem 0 0.5rem 1rem;
+      }
+      .panel-inner {
+        background: none;
+        box-shadow: none;
+        border-radius: 0;
+        padding: 0;
+      }
+      .brands-panel {
+        width: auto;
+        padding: 0.5rem 0 0;
+        margin-top: 10px;
+        border-top: 1px solid #e6e6e6;
+      }
+    }
+  </style><!--lit-part xCEnq2tI3o8=-->
+      <nav part="navbar" aria-label="Primary">
+        <slot name="logo"><!--lit-part SvgRjkC8tbs=--><!--lit-node 0--><a class="logo" part="logo" href="https://www.postman.com/" aria-label="Home">
+      <!-- alt="" because the anchor carries the accessible name; a filled alt
+           here would make screen readers announce it twice. -->
+      <img src="https://voyager.postman.com/logo/postman-logo-icon-orange.svg" alt="" width="32" height="32" />
+    </a><!--/lit-part--></slot>
+        <!--lit-node 3--><button
+          class="hamburger"
           aria-expanded="false"
-          aria-haspopup="true">
-          Product
-          <svg class="arrow-icon" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="#6b6b6b">
-            <g><path d="M10.375,3.219,6,6.719l-4.375-3.5A1,1,0,1,0,.375,4.781l5,4a1,1,0,0,0,1.25,0l5-4a1,1,0,0,0-1.25-1.562Z" /></g>
-          </svg>
-        </a>
-        <div class="dropdown-menu dropdown-menu-with-brands" aria-labelledby="Nav-Product">
-          <div class="dropdown-with-brands">
-            <div class="dropdown-inner">
-              <!-- Inner panel -->
-              <div class="dropdown-right-column dropdown-col-menu dropdown-col-menu-wide">
-                <div class="dropdown-right-col-items">
-
-                  <div class="right-col">
-                    <p class="h6 dropdown-header mb-0">DESIGN &amp; BUILD</p>
-                    <a class="dropdown-item dropdown-item-icon" href="https://www.postman.com/product/spec-hub/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'spec-hub');">
-                      <span class="nav-icon" style="background-image: url('https://voyager.postman.com/icon/spec-hub-icon-2.svg');" aria-hidden="true"></span>
-                      <span class="nav-item-text">
-                        <span class="nav-item-title">Spec Hub</span>
-                        <span class="dropdown-description">Manage specifications</span>
-                      </span>
-                    </a>
-                    <a class="dropdown-item dropdown-item-icon" href="https://www.postman.com/product/workspaces/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'collaborate-in-workspaces');">
-                      <span class="nav-icon" style="background-image: url('https://voyager.postman.com/icon/workspaces-icon-2.svg');" aria-hidden="true"></span>
-                      <span class="nav-item-text">
-                        <span class="nav-item-title">Workspaces</span>
-                        <span class="dropdown-description">Collaborate with teams</span>
-                      </span>
-                    </a>
-                    <a class="dropdown-item dropdown-item-icon" href="https://www.postman.com/product/mock-servers/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'mock-servers');">
-                      <span class="nav-icon" style="background-image: url('https://voyager.postman.com/icon/local-mock-servers-icon-2.svg');" aria-hidden="true"></span>
-                      <span class="nav-item-text">
-                        <span class="nav-item-title">Mock Servers</span>
-                        <span class="dropdown-description">Simulate API behavior</span>
-                      </span>
-                    </a>
-                    <a class="dropdown-item dropdown-item-icon" href="https://www.postman.com/product/sdk-generator/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'sdk-generator');">
-                      <span class="nav-icon" style="background-image: url('https://voyager.postman.com/icon/sdk-generator-icon-2.svg');" aria-hidden="true"></span>
-                      <span class="nav-item-text">
-                        <span class="nav-item-title">SDK Generator</span>
-                        <span class="dropdown-description">Create SDKs instantly</span>
-                      </span>
-                    </a>
-                    <a class="dropdown-item dropdown-item-icon" href="https://www.postman.com/product/flows/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'flows');">
-                      <span class="nav-icon" style="background-image: url('https://voyager.postman.com/icon/flows-local-icon-2.svg');" aria-hidden="true"></span>
-                      <span class="nav-item-text">
-                        <span class="nav-item-title">Flows</span>
-                        <span class="dropdown-description">Create visual workflows</span>
-                      </span>
-                    </a>
-                  </div>
-
-                  <div class="right-col">
-                    <p class="h6 dropdown-header mb-0">TEST &amp; VALIDATE</p>
-                    <a class="dropdown-item dropdown-item-icon" href="https://www.postman.com/product/api-client/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'product-api-client');">
-                      <span class="nav-icon" style="background-image: url('https://voyager.postman.com/icon/api-client-2.svg');" aria-hidden="true"></span>
-                      <span class="nav-item-text">
-                        <span class="nav-item-title">API Client</span>
-                        <span class="dropdown-description">Send API requests</span>
-                      </span>
-                    </a>
-                    <a class="dropdown-item dropdown-item-icon" href="https://www.postman.com/product/collection-runner/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'collection-runner');">
-                      <span class="nav-icon" style="background-image: url('https://voyager.postman.com/icon/collection-runner-2.svg');" aria-hidden="true"></span>
-                      <span class="nav-item-text">
-                        <span class="nav-item-title">Collection Runner</span>
-                        <span class="dropdown-description">Automate API workflows</span>
-                      </span>
-                    </a>
-                    <a class="dropdown-item dropdown-item-icon" href="https://www.postman.com/product/monitors/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'api-monitoring');">
-                      <span class="nav-icon" style="background-image: url('https://voyager.postman.com/icon/monitors-icon-2.svg');" aria-hidden="true"></span>
-                      <span class="nav-item-text">
-                        <span class="nav-item-title">Monitors</span>
-                        <span class="dropdown-description">Validate performance</span>
-                      </span>
-                    </a>
-                    <a class="dropdown-item dropdown-item-icon" href="https://www.postman.com/product/webhooks/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'webhooks');">
-                      <span class="nav-icon" style="background-image: url('https://voyager.postman.com/icon/webhooks-icon.svg');" aria-hidden="true"></span>
-                      <span class="nav-item-text">
-                        <span class="nav-item-title">Webhooks</span>
-                        <span class="dropdown-description">First-class webhook support</span>
-                      </span>
-                    </a>
-                  </div>
-
-                  <div class="right-col">
-                    <p class="h6 dropdown-header mb-0">MANAGE &amp; OPERATE</p>
-                    <a class="dropdown-item dropdown-item-icon" href="https://www.postman.com/product/api-catalog/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'api-catalog');">
-                      <span class="nav-icon" style="background-image: url('https://voyager.postman.com/icon/api-catalog-2.svg');" aria-hidden="true"></span>
-                      <span class="nav-item-text">
-                        <span class="nav-item-title">API Catalog</span>
-                        <span class="dropdown-description">Know every API and service</span>
-                      </span>
-                    </a>
-                    <a class="dropdown-item dropdown-item-icon" href="https://www.postman.com/product/postman-insights/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'postman-insights');">
-                      <span class="nav-icon" style="background-image: url('https://voyager.postman.com/icon/insights-icon-2.svg');" aria-hidden="true"></span>
-                      <span class="nav-item-text">
-                        <span class="nav-item-title">Insights</span>
-                        <span class="dropdown-description">Track every endpoint</span>
-                      </span>
-                    </a>
-                  </div>
-
-                  <!-- Platform -->
-                  <aside class="dropdown-left-column">
-                    <p class="h6 dropdown-header mb-0">PLATFORM</p>
-                    <a class="dropdown-item" href="https://www.postman.com/new-postman/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'whats-new');">
-                      What's New
-                      <span class="gradient"></span>
-                    </a>
-                    <a class="dropdown-item" href="https://www.postman.com/security/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'security');">
-                      Security
-                    </a>
-                    <a class="dropdown-item" href="https://www.postman.com/product/integrations/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'integrations');">
-                      Integrations
-                    </a>
-
-                    <p class="h6 dropdown-header mb-0">EXPLORE</p>
-                    <a class="dropdown-item" href="https://www.postman.com/explore" onClick="ga('send', 'event', 'global-navbar', 'Click', 'explore');">
-                      Postman API Network
-                    </a>
-                    <a class="dropdown-item" href="https://www.postman.com/explore/mcp-servers" onClick="ga('send', 'event', 'global-navbar', 'Click', 'mcp-servers');">
-                      MCP Server Catalog
-                    </a>
-                    <div class="dropdown-download-cta">
-                    <a class="app-cta" href="https://www.postman.com/downloads/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'download-postman');">
-                      Download Postman →
-                    </a>
-                    </div>
-                  </aside>
-
-                </div>
-
-                <!-- Footer cards -->
-                <div class="nav-footer-block">
-                  <div class="nav-footer-row product-footer-row">
-                    <a class="footer-card footer-card--pink" href="https://www.postman.com/product/ai-engineer/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'ai-engineer');">
-                      <span class="footer-card-bg" aria-hidden="true"></span>
-                      <span class="footer-card-content">
-                        <span class="nav-icon nav-icon--dark" style="background-image: url('https://voyager.postman.com/icon/postman-ai-engineer-icon-3.svg');" aria-hidden="true"></span>
-                        <span class="nav-item-text">
-                          <span class="nav-item-title">AI Engineer</span>
-                          <span class="dropdown-description">AI Engineer is ready to help</span>
-                        </span>
-                      </span>
-                    </a>
-                    <a class="footer-card footer-card--orange" href="https://www.postman.com/product/agent-mode/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'agent-mode');">
-                      <span class="footer-card-bg" aria-hidden="true"></span>
-                      <span class="footer-card-content">
-                        <span class="nav-icon nav-icon--dark" style="background-image: url('https://voyager.postman.com/icon/postman-agent-mode-icon-2.svg');" aria-hidden="true"></span>
-                        <span class="nav-item-text">
-                          <span class="nav-item-title">Agent Mode</span>
-                          <span class="dropdown-description">Automate API workflows with native AI</span>
-                        </span>
-                      </span>
-                    </a>
-                    <a class="footer-card footer-card--yellow" href="https://www.postman.com/product/postman-cli/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'postman-cli');">
-                      <span class="footer-card-bg" aria-hidden="true"></span>
-                      <span class="footer-card-content">
-                        <span class="nav-icon nav-icon--dark" style="background-image: url('https://voyager.postman.com/icon/postman-cli-icon-2.svg');" aria-hidden="true"></span>
-                        <span class="nav-item-text">
-                          <span class="nav-item-title">Postman CLI</span>
-                          <span class="dropdown-description">Work with Postman from the command line</span>
-                        </span>
-                      </span>
-                    </a>
-                    <a class="footer-card footer-card--purple" href="https://www.postman.com/product/mcp-server/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'mcp-server');">
-                      <span class="footer-card-bg" aria-hidden="true"></span>
-                      <span class="footer-card-content">
-                        <span class="nav-icon nav-icon--dark" style="background-image: url('https://voyager.postman.com/icon/postman-mcp-icon-2.svg');" aria-hidden="true"></span>
-                        <span class="nav-item-text">
-                          <span class="nav-item-title">Postman MCP Server</span>
-                          <span class="dropdown-description">Give API context to your AI agents</span>
-                        </span>
-                      </span>
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Brands -->
-            <aside class="dropdown-brands-panel">
-              <p class="h6 dropdown-header dropdown-brands-header mb-0">MORE FROM POSTMAN</p>
-              <a class="brand-item" href="https://astropods.com/" rel="noopener noreferrer" target="_blank" onClick="ga('send', 'event', 'global-navbar', 'Click', 'astro-ai');">
-                <span class="nav-icon nav-icon--passthrough" style="background-image: url('https://voyager.postman.com/icon/external/astro-ai-logo-icon.svg');" aria-hidden="true"></span>
-                <span class="nav-item-text">
-                  <span class="nav-item-title">
-                    Astro AI
-                    <span class="brand-arrow" aria-hidden="true">
-                      <span class="brand-arrow-bar"></span>
-                      <svg xmlns="http://www.w3.org/2000/svg" width="5" height="9" viewBox="9 0 5 8" fill="currentColor" class="brand-arrow-chevron">
-                        <path d="M13.3536 4.03553C13.5488 3.84027 13.5488 3.52369 13.3536 3.32843L10.1716 0.146447C9.97631 -0.0488155 9.65973 -0.0488155 9.46447 0.146447C9.2692 0.341709 9.2692 0.658291 9.46447 0.853554L12.2929 3.68198L9.46447 6.51041C9.2692 6.70567 9.2692 7.02225 9.46447 7.21751C9.65973 7.41278 9.97631 7.41278 10.1716 7.21751L13.3536 4.03553Z"/>
-                      </svg>
-                    </span>
-                  </span>
-                  <span class="dropdown-description">Manage and control AI agents in production</span>
-                </span>
-              </a>
-              <a class="brand-item" href="https://buildwithfern.com/" rel="noopener noreferrer" target="_blank" onClick="ga('send', 'event', 'global-navbar', 'Click', 'fern');">
-                <span class="nav-icon nav-icon--passthrough" style="background-image: url('https://voyager.postman.com/icon/external/fern-docs-leaf-icon.svg');" aria-hidden="true"></span>
-                <span class="nav-item-text">
-                  <span class="nav-item-title">
-                    Fern
-                    <span class="brand-arrow" aria-hidden="true">
-                      <span class="brand-arrow-bar"></span>
-                      <svg xmlns="http://www.w3.org/2000/svg" width="5" height="9" viewBox="9 0 5 8" fill="currentColor" class="brand-arrow-chevron">
-                        <path d="M13.3536 4.03553C13.5488 3.84027 13.5488 3.52369 13.3536 3.32843L10.1716 0.146447C9.97631 -0.0488155 9.65973 -0.0488155 9.46447 0.146447C9.2692 0.341709 9.2692 0.658291 9.46447 0.853554L12.2929 3.68198L9.46447 6.51041C9.2692 6.70567 9.2692 7.02225 9.46447 7.21751C9.65973 7.41278 9.97631 7.41278 10.1716 7.21751L13.3536 4.03553Z"/>
-                      </svg>
-                    </span>
-                  </span>
-                  <span class="dropdown-description">Instantly generate API docs and SDKs</span>
-                </span>
-              </a>
-            </aside>
-
-          </div>
+          aria-controls="menubar"
+          
+        >
+          Menu
+        </button>
+        <!--lit-node 4--><ul
+          id="menubar"
+          class="menubar"
+          part="menubar"
+          role="menubar"
+          aria-label="Primary"
+          aria-orientation="horizontal"
+          data-mobile-open="false"
+          
+        >
+          <!--lit-part--><!--lit-part 6jR3+WBNtW4=--><li class="item" role="none">
+                  <!--lit-part Ag/IPlHBETg=--><!--lit-node 0--><button
+      id="trigger-product"
+      class="trigger"
+      part="menu-trigger"
+      role="menuitem"
+      tabindex="0"
+      aria-expanded="false"
+      aria-haspopup="true"
+      aria-controls="panel-product"
+      
+    >
+      <span><!--lit-part-->Product<!--/lit-part--></span>
+      <svg
+        class="chevron"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+        width="12"
+        height="12"
+        viewBox="0 0 12 12"
+        fill="currentColor"
+      >
+        <path
+          d="M10.375,3.219,6,6.719l-4.375-3.5A1,1,0,1,0,.375,4.781l5,4a1,1,0,0,0,1.25,0l5-4a1,1,0,0,0-1.25-1.562Z"
+        ></path>
+      </svg>
+    </button><!--/lit-part--><!--lit-part 8LrBfkHG42Q=--><!--lit-node 0--><div
+      id="panel-product"
+      part="panel"
+      class="panel has-brands"
+      role="region"
+      aria-label="Product"
+      hidden
+      
+    >
+      <!--lit-part 1m7IJyrRrSQ=-->
+              <div class="panel-inner"><!--lit-part r9tjawXZNgc=-->
+      <!--lit-part b19ok/bgW/U=--><div class="columns">
+        <!--lit-part--><!--lit-part 73MTHBZy4yQ=--><!--lit-node 0--><div class="col w210">
+      <!--lit-part oxgaMnJ0t+s=--><p class="col-title"><!--lit-part-->Design &amp; Build<!--/lit-part--></p><!--/lit-part-->
+      <ul>
+        <!--lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/product/spec-hub/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/spec-hub-icon-2.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Spec Hub<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Manage specifications<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/product/workspaces/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/workspaces-icon-2.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Workspaces<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Collaborate with teams<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/product/mock-servers/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/local-mock-servers-icon-2.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Mock Servers<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Simulate API behavior<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/product/sdk-generator/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/sdk-generator-icon-2.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->SDK Generator<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Create SDKs instantly<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/product/flows/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/flows-local-icon-2.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Flows<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Create visual workflows<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--/lit-part-->
+      </ul>
+    </div><!--/lit-part--><!--lit-part 73MTHBZy4yQ=--><!--lit-node 0--><div class="col w210">
+      <!--lit-part oxgaMnJ0t+s=--><p class="col-title"><!--lit-part-->Test &amp; Validate<!--/lit-part--></p><!--/lit-part-->
+      <ul>
+        <!--lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/product/api-client/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/api-client-2.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->API Client<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Send API requests<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/product/collection-runner/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/collection-runner-2.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Collection Runner<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Automate API workflows<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/product/monitors/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/monitors-icon-2.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Monitors<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Validate performance<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/product/webhooks/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/webhooks-icon.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Webhooks<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->First-class webhook support<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--/lit-part-->
+      </ul>
+    </div><!--/lit-part--><!--lit-part 73MTHBZy4yQ=--><!--lit-node 0--><div class="col w210">
+      <!--lit-part oxgaMnJ0t+s=--><p class="col-title"><!--lit-part-->Manage &amp; Operate<!--/lit-part--></p><!--/lit-part-->
+      <ul>
+        <!--lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/product/api-catalog/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/api-catalog-2.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->API Catalog<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Know every API and service<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/product/postman-insights/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/insights-icon-2.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Insights<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Track every endpoint<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--/lit-part-->
+      </ul>
+    </div><!--/lit-part--><!--/lit-part--><!--lit-part 73MTHBZy4yQ=--><!--lit-node 0--><div class="col left-nav">
+      <!--lit-part oxgaMnJ0t+s=--><p class="col-title"><!--lit-part-->Platform<!--/lit-part--></p><!--/lit-part-->
+      <ul>
+        <!--lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/new-postman/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->What&#39;s New<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/security/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Security<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/product/integrations/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Integrations<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part MkpDcwos3Mo=--><li class="section-header" role="presentation"><!--lit-part-->Explore<!--/lit-part--></li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/explore"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Postman API Network<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/explore/mcp-servers"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->MCP Server Catalog<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item app-cta "
+        part="nav-link"
+        
+        href="https://www.postman.com/downloads/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Download Postman →<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--/lit-part-->
+      </ul>
+    </div><!--/lit-part-->
+      </div><!--/lit-part-->
+      <!--lit-part +ra7spn/DWQ=--><div class="featured">
+              <ul class="card-row">
+                <!--lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  feat-card"
+        part="nav-link"
+        style="background:linear-gradient(99deg, #FFCCFC 0%, rgba(207, 207, 207, 0.00) 100%);--ring:#F37FFE"
+        href="https://www.postman.com/product/ai-engineer/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/postman-ai-engineer-icon-3.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->AI Engineer<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->AI Engineer is ready to help<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  feat-card"
+        part="nav-link"
+        style="background:linear-gradient(275deg, rgba(161, 161, 161, 0.00) 0%, rgba(255, 108, 55, 0.20) 100%);--ring:#FF6C37"
+        href="https://www.postman.com/product/agent-mode/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/postman-agent-mode-icon-2.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Agent Mode<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Automate API workflows with native AI<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  feat-card"
+        part="nav-link"
+        style="background:linear-gradient(275deg, rgba(207, 207, 207, 0.00) 0%, rgba(255, 216, 117, 0.20) 100%);--ring:#FFA90A"
+        href="https://www.postman.com/product/postman-cli/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/postman-cli-icon-2.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Postman CLI<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Work with Postman from the command line<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  feat-card"
+        part="nav-link"
+        style="background:linear-gradient(275deg, rgba(207, 207, 207, 0.00) 0%, rgba(179, 135, 245, 0.20) 100%);--ring:#7A24F0"
+        href="https://www.postman.com/product/mcp-server/"
+        
+        
+        
+      >
+        <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/postman-mcp-icon-2.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Postman MCP Server<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Give API context to your AI agents<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--/lit-part-->
+              </ul>
+            </div><!--/lit-part-->
+    <!--/lit-part--></div>
+              <aside class="brands-panel" part="brands">
+                <p class="col-title">More from Postman</p>
+                <!--lit-part--><!--lit-part 8REdX04aCUw=--><!--lit-node 0--><a
+      class="brand-item"
+      part="nav-link"
+      href="https://www.postman.com/fabric-gateway/"
+      
+      
+      
+    >
+      <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/logo/fabric-gateway-mark-gradient.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+      <span class="text">
+        <span class="title"
+          ><!--lit-part-->Fabric Gateway<!--/lit-part-->
+          <span class="brand-arrow" aria-hidden="true">
+            <span class="bar"></span>
+            <svg
+              class="chev"
+              xmlns="http://www.w3.org/2000/svg"
+              width="5"
+              height="9"
+              viewBox="9 0 5 8"
+              fill="currentColor"
+            >
+              <path
+                d="M13.3536 4.03553C13.5488 3.84027 13.5488 3.52369 13.3536 3.32843L10.1716 0.146447C9.97631 -0.0488155 9.65973 -0.0488155 9.46447 0.146447C9.2692 0.341709 9.2692 0.658291 9.46447 0.853554L12.2929 3.68198L9.46447 6.51041C9.2692 6.70567 9.2692 7.02225 9.46447 7.21751C9.65973 7.41278 9.97631 7.41278 10.1716 7.21751L13.3536 4.03553Z"
+              ></path>
+            </svg>
+          </span>
+        </span>
+        <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Route, govern, and observe your AI traffic<!--/lit-part--></span><!--/lit-part-->
+      </span>
+    </a><!--/lit-part--><!--lit-part 8REdX04aCUw=--><!--lit-node 0--><a
+      class="brand-item"
+      part="nav-link"
+      href="https://buildwithfern.com/"
+      
+      
+      
+    >
+      <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/external/fern-docs-leaf-icon.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+      <span class="text">
+        <span class="title"
+          ><!--lit-part-->Fern<!--/lit-part-->
+          <span class="brand-arrow" aria-hidden="true">
+            <span class="bar"></span>
+            <svg
+              class="chev"
+              xmlns="http://www.w3.org/2000/svg"
+              width="5"
+              height="9"
+              viewBox="9 0 5 8"
+              fill="currentColor"
+            >
+              <path
+                d="M13.3536 4.03553C13.5488 3.84027 13.5488 3.52369 13.3536 3.32843L10.1716 0.146447C9.97631 -0.0488155 9.65973 -0.0488155 9.46447 0.146447C9.2692 0.341709 9.2692 0.658291 9.46447 0.853554L12.2929 3.68198L9.46447 6.51041C9.2692 6.70567 9.2692 7.02225 9.46447 7.21751C9.65973 7.41278 9.97631 7.41278 10.1716 7.21751L13.3536 4.03553Z"
+              ></path>
+            </svg>
+          </span>
+        </span>
+        <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Instantly generate API docs and SDKs<!--/lit-part--></span><!--/lit-part-->
+      </span>
+    </a><!--/lit-part--><!--lit-part 8REdX04aCUw=--><!--lit-node 0--><a
+      class="brand-item"
+      part="nav-link"
+      href="https://astropods.com/"
+      
+      
+      
+    >
+      <!--lit-part 5SfixccoF5w=--><!--lit-node 0--><img src="https://voyager.postman.com/icon/external/astro-ai-logo-icon.svg" alt="" aria-hidden="true" /><!--/lit-part-->
+      <span class="text">
+        <span class="title"
+          ><!--lit-part-->Astro AI<!--/lit-part-->
+          <span class="brand-arrow" aria-hidden="true">
+            <span class="bar"></span>
+            <svg
+              class="chev"
+              xmlns="http://www.w3.org/2000/svg"
+              width="5"
+              height="9"
+              viewBox="9 0 5 8"
+              fill="currentColor"
+            >
+              <path
+                d="M13.3536 4.03553C13.5488 3.84027 13.5488 3.52369 13.3536 3.32843L10.1716 0.146447C9.97631 -0.0488155 9.65973 -0.0488155 9.46447 0.146447C9.2692 0.341709 9.2692 0.658291 9.46447 0.853554L12.2929 3.68198L9.46447 6.51041C9.2692 6.70567 9.2692 7.02225 9.46447 7.21751C9.65973 7.41278 9.97631 7.41278 10.1716 7.21751L13.3536 4.03553Z"
+              ></path>
+            </svg>
+          </span>
+        </span>
+        <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Manage and control AI agents in production<!--/lit-part--></span><!--/lit-part-->
+      </span>
+    </a><!--/lit-part--><!--/lit-part-->
+              </aside>
+            <!--/lit-part-->
+    </div><!--/lit-part-->
+                </li><!--/lit-part--><!--lit-part 6jR3+WBNtW4=--><li class="item" role="none">
+                  <!--lit-part Ag/IPlHBETg=--><!--lit-node 0--><button
+      id="trigger-solutions"
+      class="trigger"
+      part="menu-trigger"
+      role="menuitem"
+      tabindex="-1"
+      aria-expanded="false"
+      aria-haspopup="true"
+      aria-controls="panel-solutions"
+      
+    >
+      <span><!--lit-part-->Solutions<!--/lit-part--></span>
+      <svg
+        class="chevron"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+        width="12"
+        height="12"
+        viewBox="0 0 12 12"
+        fill="currentColor"
+      >
+        <path
+          d="M10.375,3.219,6,6.719l-4.375-3.5A1,1,0,1,0,.375,4.781l5,4a1,1,0,0,0,1.25,0l5-4a1,1,0,0,0-1.25-1.562Z"
+        ></path>
+      </svg>
+    </button><!--/lit-part--><!--lit-part 8LrBfkHG42Q=--><!--lit-node 0--><div
+      id="panel-solutions"
+      part="panel"
+      class="panel "
+      role="region"
+      aria-label="Solutions"
+      hidden
+      
+    >
+      <!--lit-part r9tjawXZNgc=-->
+      <!--lit-part 93yI3VTwxwY=--><ul class="solutions-grid">
+        <!--lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/solutions/api-governance/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->API Governance<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Enforce API standards at scale<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/solutions/partner-api-management/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Partner API Management<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Onboard partners in days, not months<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/solutions/api-lifecycle-management/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->API Lifecycle Management<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Run every stage as one connected system<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/solutions/sdlc-automation/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->SDLC Automation<!--/lit-part--></span>
+          <!--lit-part vIYRVBGBSHQ=--><span class="desc"><!--lit-part-->Embed quality into every delivery stage<!--/lit-part--></span><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--/lit-part-->
+      </ul><!--/lit-part-->
+      <!--lit-part--><!--/lit-part-->
+    <!--/lit-part-->
+    </div><!--/lit-part-->
+                </li><!--/lit-part--><!--lit-part CD4CAwJpRgY=--><li class="item" role="none"><!--lit-part IVugGeXMSMo=--><!--lit-node 0--><a
+      class="top-link"
+      part="nav-link"
+      role="menuitem"
+      tabindex="-1"
+      href="https://www.postman.com/pricing/"
+      
+      
+      
+      ><!--lit-part-->Pricing<!--/lit-part--></a
+    ><!--/lit-part--></li><!--/lit-part--><!--lit-part CD4CAwJpRgY=--><li class="item" role="none"><!--lit-part IVugGeXMSMo=--><!--lit-node 0--><a
+      class="top-link"
+      part="nav-link"
+      role="menuitem"
+      tabindex="-1"
+      href="https://www.postman.com/postman-enterprise/"
+      
+      
+      
+      ><!--lit-part-->Enterprise<!--/lit-part--></a
+    ><!--/lit-part--></li><!--/lit-part--><!--lit-part 6jR3+WBNtW4=--><li class="item" role="none">
+                  <!--lit-part Ag/IPlHBETg=--><!--lit-node 0--><button
+      id="trigger-resources"
+      class="trigger"
+      part="menu-trigger"
+      role="menuitem"
+      tabindex="-1"
+      aria-expanded="false"
+      aria-haspopup="true"
+      aria-controls="panel-resources"
+      
+    >
+      <span><!--lit-part-->Resources<!--/lit-part--></span>
+      <svg
+        class="chevron"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+        width="12"
+        height="12"
+        viewBox="0 0 12 12"
+        fill="currentColor"
+      >
+        <path
+          d="M10.375,3.219,6,6.719l-4.375-3.5A1,1,0,1,0,.375,4.781l5,4a1,1,0,0,0,1.25,0l5-4a1,1,0,0,0-1.25-1.562Z"
+        ></path>
+      </svg>
+    </button><!--/lit-part--><!--lit-part 8LrBfkHG42Q=--><!--lit-node 0--><div
+      id="panel-resources"
+      part="panel"
+      class="panel "
+      role="region"
+      aria-label="Resources"
+      hidden
+      
+    >
+      <!--lit-part r9tjawXZNgc=-->
+      <!--lit-part b19ok/bgW/U=--><div class="columns">
+        <!--lit-part--><!--lit-part 73MTHBZy4yQ=--><!--lit-node 0--><div class="col w180">
+      <!--lit-part oxgaMnJ0t+s=--><p class="col-title"><!--lit-part-->Learn<!--/lit-part--></p><!--/lit-part-->
+      <ul>
+        <!--lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/learn/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Learning Hub<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://learning.postman.com"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Docs<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://academy.postman.com/page/enterprise-implementation-onboarding-guide"
+        target="_blank"
+        rel="noopener noreferrer"
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Enterprise Onboarding<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://academy.postman.com"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Postman Academy<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/customer-stories/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Customer Stories<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/postman-best-practices/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Postman Best Practices<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--/lit-part-->
+      </ul>
+    </div><!--/lit-part--><!--lit-part 73MTHBZy4yQ=--><!--lit-node 0--><div class="col w180">
+      <!--lit-part oxgaMnJ0t+s=--><p class="col-title"><!--lit-part-->Connect<!--/lit-part--></p><!--/lit-part-->
+      <ul>
+        <!--lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://community.postman.com"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Community<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/events/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Events<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://discord.gg/58aNNsRBGR"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Discord<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/product/mcp-server/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Postman MCP Server<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/partner-program/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Partner Program<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--/lit-part-->
+      </ul>
+    </div><!--/lit-part--><!--lit-part 73MTHBZy4yQ=--><!--lit-node 0--><div class="col w180">
+      <!--lit-part oxgaMnJ0t+s=--><p class="col-title"><!--lit-part-->Tools<!--/lit-part--></p><!--/lit-part-->
+      <ul>
+        <!--lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/tools/spechub-visualizer-and-linter"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Spec editor and visualizer<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/tools/api-health-check"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Check API health<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/tools/is-it-up"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Check site uptime<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/tools/site-speed-checker"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Check site speed<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/tools/curl-to-code"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->cURL to code<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/tools"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->See all tools →<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--/lit-part-->
+      </ul>
+    </div><!--/lit-part--><!--lit-part 73MTHBZy4yQ=--><!--lit-node 0--><div class="col w180">
+      <!--lit-part oxgaMnJ0t+s=--><p class="col-title"><!--lit-part-->Get Support<!--/lit-part--></p><!--/lit-part-->
+      <ul>
+        <!--lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://support.postman.com/hc/en-us/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Support Center<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/release-notes/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Release Notes<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://status.postman.com"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Postman Status<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/security/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Security<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--/lit-part-->
+      </ul>
+    </div><!--/lit-part--><!--lit-part 73MTHBZy4yQ=--><!--lit-node 0--><div class="col w180">
+      <!--lit-part oxgaMnJ0t+s=--><p class="col-title"><!--lit-part-->Postman<!--/lit-part--></p><!--/lit-part-->
+      <ul>
+        <!--lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://blog.postman.com"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Blog<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/company/press-media/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->Press and Media<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--lit-part KkH6yAay17M=--><li>
+      <!--lit-node 1--><a
+        class="menu-item  "
+        part="nav-link"
+        
+        href="https://www.postman.com/company/about-postman/"
+        
+        
+        
+      >
+        <!--lit-part--><!--/lit-part-->
+        <span class="text">
+          <span class="title"><!--lit-part-->About Postman<!--/lit-part--></span>
+          <!--lit-part--><!--/lit-part-->
+        </span>
+      </a>
+    </li><!--/lit-part--><!--/lit-part-->
+      </ul>
+    </div><!--/lit-part--><!--/lit-part-->
+      </div><!--/lit-part-->
+      <!--lit-part--><!--/lit-part-->
+    <!--/lit-part-->
+    </div><!--/lit-part-->
+                </li><!--/lit-part--><!--/lit-part-->
+          <li class="item mobile-account" role="none">
+            <slot name="account-mobile"><!--lit-part KiZeL1tOw0U=--><!--lit-node 0--><div class="acct-group acct-mobile">
+      <!--lit-part 9LHhsf+BtZQ=--><!--lit-node 0--><a class="acct acct-secondary" part="account-link" href="https://www.postman.com/company/contact-sales/"><!--lit-part-->Contact Sales<!--/lit-part--></a><!--/lit-part-->
+      <!--lit-part--><!--lit-part 9LHhsf+BtZQ=--><!--lit-node 0--><a class="acct acct-secondary" part="account-link" href="https://identity.getpostman.com/login"><!--lit-part-->Sign In<!--/lit-part--></a><!--/lit-part--><!--lit-part 9LHhsf+BtZQ=--><!--lit-node 0--><a class="acct acct-primary" part="account-link" href="https://identity.getpostman.com/signup"><!--lit-part-->Sign Up for Free<!--/lit-part--></a><!--/lit-part--><!--/lit-part-->
+    </div><!--/lit-part--></slot>
+          </li>
+        </ul>
+        <div class="actions">
+          <slot name="search"></slot>
+          <slot name="local-nav"></slot>
+          <slot name="account"><!--lit-part KiZeL1tOw0U=--><!--lit-node 0--><div class="acct-group ">
+      <!--lit-part 9LHhsf+BtZQ=--><!--lit-node 0--><a class="acct acct-secondary" part="account-link" href="https://www.postman.com/company/contact-sales/"><!--lit-part-->Contact Sales<!--/lit-part--></a><!--/lit-part-->
+      <!--lit-part--><!--lit-part 9LHhsf+BtZQ=--><!--lit-node 0--><a class="acct acct-secondary" part="account-link" href="https://identity.getpostman.com/login"><!--lit-part-->Sign In<!--/lit-part--></a><!--/lit-part--><!--lit-part 9LHhsf+BtZQ=--><!--lit-node 0--><a class="acct acct-primary" part="account-link" href="https://identity.getpostman.com/signup"><!--lit-part-->Sign Up for Free<!--/lit-part--></a><!--/lit-part--><!--/lit-part-->
+    </div><!--/lit-part--></slot>
         </div>
-      </li>
-
-      <!-- Solutions -->
-      <li class="nav-item dropdown">
-        <a
-          class="nav-link dropdown-toggle"
-          href="#"
-          id="Nav-Solutions"
-          data-bs-toggle="dropdown"
-          data-bs-display="static"
-          aria-expanded="false"
-          aria-haspopup="true">
-          Solutions
-          <svg class="arrow-icon" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="#6b6b6b">
-            <g><path d="M10.375,3.219,6,6.719l-4.375-3.5A1,1,0,1,0,.375,4.781l5,4a1,1,0,0,0,1.25,0l5-4a1,1,0,0,0-1.25-1.562Z" /></g>
-          </svg>
-        </a>
-        <div class="dropdown-menu dropdown-menu-solutions" aria-labelledby="Nav-Solutions">
-          <div class="solutions-grid">
-            <a class="dropdown-item" href="https://www.postman.com/solutions/api-governance/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'api-governance');">
-              <span class="nav-item-title">API Governance</span>
-              <span class="dropdown-description">Enforce API standards at scale</span>
-            </a>
-            <a class="dropdown-item" href="https://www.postman.com/solutions/api-lifecycle-management/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'api-lifecycle-management');">
-              <span class="nav-item-title">API Lifecycle Management</span>
-              <span class="dropdown-description">Run every stage as one connected system</span>
-            </a>
-            <a class="dropdown-item" href="https://www.postman.com/solutions/partner-api-management/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'partner-api-management');">
-              <span class="nav-item-title">Partner API Management</span>
-              <span class="dropdown-description">Onboard partners in days, not months</span>
-            </a>
-            <a class="dropdown-item" href="https://www.postman.com/solutions/sdlc-automation/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'sdlc-automation');">
-              <span class="nav-item-title">SDLC Automation</span>
-              <span class="dropdown-description">Embed quality into every delivery stage</span>
-            </a>
-          </div>
-        </div>
-      </li>
-
-      <!-- Pricing -->
-      <li class="nav-item">
-        <a
-          class="nav-link"
-          id="Nav-Pricing"
-          href="https://www.postman.com/pricing/"
-          onClick="ga('send', 'event', 'global-navbar', 'Click', 'pricing');">
-          Pricing
-        </a>
-      </li>
-
-      <!-- Enterprise -->
-      <li class="nav-item">
-        <a
-          class="nav-link"
-          id="Nav-Enterprise"
-          href="https://www.postman.com/postman-enterprise/"
-          onClick="ga('send', 'event', 'global-navbar', 'Click', 'postman-enterprise');">
-          Enterprise
-        </a>
-      </li>
-
-      <!-- Resources -->
-      <li class="nav-item dropdown">
-        <a
-          class="nav-link dropdown-toggle"
-          href="#"
-          id="Nav-Resources"
-          data-bs-toggle="dropdown"
-          data-bs-display="static"
-          aria-expanded="false"
-          aria-haspopup="true">
-          Resources
-          <svg class="arrow-icon" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="#6b6b6b">
-            <g><path d="M10.375,3.219,6,6.719l-4.375-3.5A1,1,0,1,0,.375,4.781l5,4a1,1,0,0,0,1.25,0l5-4a1,1,0,0,0-1.25-1.562Z" /></g>
-          </svg>
-        </a>
-        <div class="dropdown-menu" aria-labelledby="Nav-Resources">
-          <div class="row dropdown-col-menu">
-            <div class="col-sm-6 col-md-3 dropdown-col">
-              <p class="h6 dropdown-header mb-0">LEARN</p>
-              <a class="dropdown-item" href="https://www.postman.com/learn/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'learn');">Learning Hub</a>
-              <a class="dropdown-item" href="https://learning.postman.com/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'docs');">Docs</a>
-              <a class="dropdown-item" href="https://academy.postman.com/page/enterprise-implementation-onboarding-guide" onClick="ga('send', 'event', 'global-navbar', 'Click', 'enterprise-onboarding');" rel="noreferrer" target="_blank">Enterprise Onboarding</a>
-              <a class="dropdown-item" href="https://academy.postman.com/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'postman-academy');" rel="noreferrer" target="_blank">Postman Academy</a>
-              <a class="dropdown-item" href="https://www.postman.com/templates/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'postman-templates');" rel="noreferrer" target="_blank">Templates</a>
-              <a class="dropdown-item" href="https://www.postman.com/customer-stories/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'customer-stories');" rel="noreferrer" target="_blank">Customer Stories</a>
-              <a class="dropdown-item" href="https://www.postman.com/postman-best-practices/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'postman-best-practices');" rel="noreferrer" target="_blank">Postman Best Practices</a>
-            </div>
-            <div class="col-sm-6 col-md-3 dropdown-col">
-              <p class="h6 dropdown-header mb-0">CONNECT</p>
-              <a class="dropdown-item" href="https://community.postman.com/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'community');">Community</a>
-              <a class="dropdown-item" href="https://www.postman.com/events/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'events');">Events</a>
-              <a class="dropdown-item" href="https://discord.gg/58aNNsRBGR" onClick="ga('send', 'event', 'global-navbar', 'Click', 'discord');" rel="noreferrer noopener" target="_blank">Discord</a>
-              <a class="dropdown-item" href="https://www.postman.com/product/mcp-server/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'mcp-server');">Postman MCP Server</a>
-            </div>
-            <div class="col-sm-6 col-md-3 dropdown-col">
-              <p class="h6 dropdown-header mb-0">GET SUPPORT</p>
-              <a class="dropdown-item" href="https://support.postman.com/hc/en-us/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'support-center');">Support Center</a>
-              <a class="dropdown-item" href="https://www.postman.com/release-notes/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'release-notes');">Release Notes</a>
-              <a class="dropdown-item" href="https://status.postman.com/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'postman-status');" target="_blank" rel="noreferrer">Postman Status</a>
-              <a class="dropdown-item" href="https://www.postman.com/security/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'trust-and-security');" id="Nav-Resources-Security" target="_blank" rel="noreferrer">Security</a>
-            </div>
-            <div class="col-sm-6 col-md-3 dropdown-col">
-              <p class="h6 dropdown-header mb-0">POSTMAN</p>
-              <a class="dropdown-item" href="https://blog.postman.com/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'blog');">Blog</a>
-              <a class="dropdown-item" href="https://www.postman.com/company/press-media/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'press-media');">Press and Media</a>
-              <a class="dropdown-item" href="https://www.postman.com/company/about-postman/" onClick="ga('send', 'event', 'global-navbar', 'Click', 'about-postman');">About Postman</a>
-            </div>
-          </div>
-        </div>
-      </li>
-
-    </ul>
-
-    <!-- Auth buttons -->
-    <div class="form-inline my-2 my-lg-0 ms-0">
-      <a
-        class="button-secondary nav-link uber-nav-link uber-nav_right contact-sales-button"
-        href="https://www.postman.com/company/contact-sales/"
-        title="Contact Sales"
-        aria-label="Contact Sales"
-        onClick="ga('send', 'event', 'global-navbar', 'Click', 'contact-sales');">
-        Contact Sales
-      </a>
-      <a
-        class="button-secondary nav-link uber-nav-link uber-nav_right pingdom-transactional-check__sign-in-button nav-sign-in-button d-none"
-        href="https://identity.getpostman.com/login?continue=https%3A%2F%2Fgo.postman.co%2Fhome"
-        title="Sign In"
-        aria-label="Sign In"
-        onClick="ga('send', 'event', 'global-navbar', 'Click', 'sign-in');">
-        Sign In
-      </a>
-      <a
-        class="button-primary nav-link uber-nav-link uber-nav_right pingdom-transactional-check__register-button nav-sign-up-button d-none"
-        title="Sign Up for Free"
-        aria-label="Sign Up for Free"
-        href="https://identity.getpostman.com/signup?continue=https%3A%2F%2Fgo.postman.co%2Fbuild"
-        onClick="ga('send', 'event', 'global-navbar', 'Click', 'sign-up');"
-        style="white-space: nowrap;">
-        Sign Up for Free
-      </a>
-      <a
-        class="button-primary nav-link uber-nav-link uber-nav_right pingdom-transactional-check__launch-button nav-launch-postman-button d-none"
-        title="Launch Postman"
-        aria-label="Launch Postman"
-        href="https://go.postman.co/home"
-        onClick="ga('send', 'event', 'global-navbar', 'Click', 'launch-postman');">
-        Launch Postman
-      </a>
-    </div>
+      </nav>
+    <!--/lit-part--></template>
+  <div slot="account" class="pm-support-account">
+    {{#if signed_in}}
+      <a class="nav-link uber-nav" href="https://support.postman.com/hc/en-us/requests"
+        onClick="ga('send', 'event', 'global-navbar', 'Click', 'my-requests');">My requests</a>
+      <a class="nav-link uber-nav" href="https://support.postman.com/access/logout?return_to=https%3A%2F%2Fsupport.postman.com%2Fhc%2Fen-us"
+        onClick="ga('send', 'event', 'global-navbar', 'Click', 'sign-out');">Sign out</a>
+    {{else}}
+      <a class="nav-link uber-nav" href="/hc/en-us/signin"
+        onClick="ga('send', 'event', 'global-navbar', 'Click', 'sign-in');">Sign in</a>
+    {{/if}}
   </div>
-</nav>
+  <div slot="account-mobile" class="pm-support-account">
+    {{#if signed_in}}
+      <a class="nav-link uber-nav" href="https://support.postman.com/hc/en-us/requests">My requests</a>
+      <a class="nav-link uber-nav" href="https://support.postman.com/access/logout?return_to=https%3A%2F%2Fsupport.postman.com%2Fhc%2Fen-us">Sign out</a>
+    {{else}}
+      <a class="nav-link uber-nav" href="/hc/en-us/signin">Sign in</a>
+    {{/if}}
+  </div>
+</postman-navbar><!--/lit-part-->
 
-<!-- Support Center Secondary Navbar -->
 <nav class="navbar-v6 navbar sticky-top navbar-expand-xl navbar-light nav-secondary">
   <div class="dropdown position-static">
     <a


### PR DESCRIPTION
**DRAFT / DO NOT MERGE — for discussion.**

Replaces the hand-inlined global nav and footer with `<postman-navbar>` / `<postman-footer>` from `postman-eng/marketing-global-navbar-footer`, the same component now integrated in www-next, the blog theme and the Fern docs site.

```
templates/header.hbs   524 -> 119 lines
templates/footer.hbs   363 ->  55 lines
```

No build step, no npm, no Node, no registry credentials — which is what makes this viable in a Zendesk theme at all. The navbar is static prerendered HTML fetched with curl; the bundle is one `<script>` tag.

## Server-rendered, not client-mounted

Zendesk emits this template, so the browser's parser sees the `<template shadowrootmode>` and attaches the shadow root — the markup and its links are in the initial HTML, which matters on a support site that relies on organic search. The earlier plan assumed a client-mount fallback would be needed here; it isn't.

Verified safe for Handlebars before inlining: the fragment contains zero `{{` or `}}` sequences, so nothing in it is parsed as a Handlebars expression. Worth checking explicitly, because the shadow CSS could plausibly have produced a `}}`.

## Auth state

`signed_in` is handled server-side rather than through the JS state bridge the plan proposed: `{{#if signed_in}}signed-in{{/if}}` emits the attribute directly, and the account slots carry the support-specific links (Sign in / My requests / Sign out). That is simpler and has no flash between paint and hydration.

## Kept unchanged

The secondary support nav with its `{{search}}` helper and Discord link, and the Transcend consent handler now projected into the footer's `privacy` slot.

## Dropped deliberately, because the component renders them

- The Privacy Policy link (same `privacy.postman.com/policies/` target)
- The copyright line
- The `DOMContentLoaded` script that patched `#current-year` — the markup had 2024 hardcoded, so that script existed to correct a stale year the component simply computes

## One script, the HYDRATE build

It adopts the prerendered navbar in place instead of re-rendering it, and registers `<postman-footer>` too. **Version and integrity must move together and must match the inlined fragment's version.**

## Verification

Verified in Chrome against a simulation of Zendesk's rendered output: the navbar adopts its prerendered shadow root cleanly — sampled 24 times through hydration, never more than one nav or one panel, so no re-render and no duplicate — the mega-menu opens, both account slots project the signed-in links, the footer mounts with 50 links, the privacy slot projects, and links resolve to absolute `www.postman.com` URLs as the `foreign` variant requires.

Generated with [Claude Code](https://claude.com/claude-code)
